### PR TITLE
dev: Fix lint pre-commit and jest environment

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/
 dist/
 .eslintrc.js
+demo/build/

--- a/jest.config.ts
+++ b/jest.config.ts
@@ -10,7 +10,7 @@ export default async (): Promise<Config.InitialOptions> => {
     moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, {
       prefix: '<rootDir>/',
     }),
-    testEnvironment: 'node',
+    testEnvironment: 'jsdom',
     testMatch: ['<rootDir>/tests/**/*(*.)@(spec|test).ts'],
   };
 };

--- a/package.json
+++ b/package.json
@@ -62,6 +62,6 @@
     "yarn": "1.22.17"
   },
   "lint-staged": {
-    "*.{js,jsx,ts,tsx}": "yarn lint --cache --fix"
+    "*.{js,jsx,ts,tsx}": "yarn eslint --cache --fix"
   }
 }


### PR DESCRIPTION
We do need jsdom for testing (we use `window` namespace)