### PR TITLE
fix(demo): Fix broken local reference to sentry-replay

### DIFF
--- a/demo/package.json
+++ b/demo/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "@sentry/browser": ">=6.18.2",
-    "@sentry/replay": "file:..",
+    "@sentry/replay": "file:../dist",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",
     "@testing-library/user-event": "^13.5.0",

--- a/demo/yarn.lock
+++ b/demo/yarn.lock
@@ -1482,8 +1482,8 @@
     "@sentry/types" "6.18.2"
     tslib "^1.9.3"
 
-"@sentry/replay@file:..":
-  version "0.0.1"
+"@sentry/replay@file:../dist":
+  version "0.0.0"
 
 "@sentry/types@6.18.2":
   version "6.18.2"


### PR DESCRIPTION
When I went into the demo folder and did yarn install followed by yarn build, I hit this error:

Module not found: Error: Can't resolve '@sentry/replay' in '/Users/user/sentry-replay/demo/src'
Pointing the dependency at the dist folder (where the JS module is published) seems to have fixed it.