### PR TITLE
fix: Fix user agent context not being applied

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,12 @@ import {
   ReplayPerformanceEntry,
 } from './createPerformanceEntry';
 import { ReplaySession } from './session';
+import {
+  REPLAY_EVENT_NAME,
+  ROOT_REPLAY_NAME,
+  SESSION_IDLE_DURATION,
+  VISIBILITY_CHANGE_TIMEOUT,
+} from './session/constants';
 import { getSession } from './session/getSession';
 import { updateSessionActivity } from './session/updateSessionActivity';
 import { isExpired } from './util/isExpired';
@@ -40,9 +46,6 @@ interface SentryReplayConfiguration extends PluginOptions {
    */
   rrwebConfig?: RRWebOptions;
 }
-
-const VISIBILITY_CHANGE_TIMEOUT = 60000; // 1 minute
-const SESSION_IDLE_DURATION = 900000; // 15 minutes
 
 export class SentryReplay {
   /**
@@ -143,6 +146,11 @@ export class SentryReplay {
     // Tag all (non replay) events that get sent to Sentry with the current
     // replay ID so that we can reference them later in the UI
     Sentry.addGlobalEventProcessor((event: Event) => {
+      // Do not apply replayId to the root transaction
+      if (event.transaction === ROOT_REPLAY_NAME) {
+        return event;
+      }
+
       event.tags = { ...event.tags, replayId: this.session.id };
       return event;
     });
@@ -303,7 +311,7 @@ export class SentryReplay {
   createReplayEvent() {
     logger.log('CreateReplayEvent rootReplayId', this.session.id);
     this.replayEvent = Sentry.startTransaction({
-      name: 'sentry-replay-event',
+      name: REPLAY_EVENT_NAME,
       parentSpanId: this.session.spanId,
       traceId: this.session.traceId,
       tags: {

--- a/src/session/constants.ts
+++ b/src/session/constants.ts
@@ -1,1 +1,8 @@
 export const REPLAY_SESSION_KEY = 'sentryReplaySession';
+export const ROOT_REPLAY_NAME = 'sentry-replay';
+export const REPLAY_EVENT_NAME = 'sentry-replay-event';
+
+// Grace period to keep a session when a user changes tabs or hides window
+export const VISIBILITY_CHANGE_TIMEOUT = 60000; // 1 minute
+// The idle limit for a session
+export const SESSION_IDLE_DURATION = 900000; // 15 minutes

--- a/src/session/createSession.ts
+++ b/src/session/createSession.ts
@@ -3,6 +3,7 @@ import * as Sentry from '@sentry/browser';
 import { logger } from '@/util/logger';
 import { saveSession } from './saveSession';
 import type { ReplaySession } from './types';
+import { ROOT_REPLAY_NAME } from './constants';
 
 interface CreateSessionParams {
   /**
@@ -23,7 +24,7 @@ export function createSession({
 
   // Create root replay event, this is where attachments will be saved
   const transaction = Sentry.getCurrentHub().startTransaction({
-    name: 'sentry-replay',
+    name: ROOT_REPLAY_NAME,
     tags: {
       isReplayRoot: 'yes',
     },


### PR DESCRIPTION
We were creating a transaction in `setupOnce`, which was being run before other integrations `setupOnce` could be run. This affected the user agent processor (see https://github.com/getsentry/sentry-javascript/blob/b47ceafbdac7f8b99093ce6023726ad4687edc48/packages/browser/src/integrations/useragent.ts). Using `setImmediate` is a workaround to wait for other `setupOnce` to run.