### PR TITLE
fix: corrected timestamp generation for createMemoryEntry()

### DIFF
--- a/src/createPerformanceEntry.ts
+++ b/src/createPerformanceEntry.ts
@@ -137,7 +137,6 @@ export function createMemoryEntry(memoryEntry: MemoryInfo) {
   // we can't use getAbsoluteTime because it adds the event time to
   // window.performance.timeOrigin, so we get right now instead.
   const time = new Date().getTime() / 1000;
-  console.log(time);
   return {
     type: 'memory',
     name: 'memory',


### PR DESCRIPTION
Closes #57 
Timestamps are generated using Date.getTime() / 1000 instead of getAbsoluteTime().
<!-- Describe your PR here. -->



<!--

  The following applies to third-party contributors.
  Sentry employees and contractors can delete or ignore.

-->

----

By submitting this pull request, I confirm that Sentry can use, modify, copy, and redistribute this contribution, under Sentry's choice of terms.
