### PR TITLE
feat: Add `nodeId` when capturing LCP

### DIFF
--- a/src/createPerformanceEntry.ts
+++ b/src/createPerformanceEntry.ts
@@ -50,7 +50,6 @@ export function createPerformanceEntries(entries: PerformanceEntry[]) {
 
 function createPerformanceEntry(entry: PerformanceEntry) {
   if (ENTRY_TYPES[entry.entryType] === undefined) {
-    console.log(`No handler for entry type: ${entry.entryType}`, entry);
     return null;
   }
 


### PR DESCRIPTION
The PerformanceObserver allows us to observe LCP events. The LCP performance entry has a reference to the element in the DOM that caused the LCP event. We can use this element reference to query rrweb to get the serialized rrweb metadata -- relevant to us is the nodeId. This will allow our replayer to do the inverse query and get a reference to the element in the replayer via nodeId so that we can "highlight" it.