### PR TITLE
feat(session): add sequence_id as tag and in session

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -12,7 +12,7 @@ expect.extend({
     received: jest.Mocked<SentryReplay>,
     expected: ReplaySession
   ) {
-    const pass = this.equals(received.session, expected);
+    const pass = this.equals(received.session.id, expected.id);
 
     const options = {
       isNot: this.isNot,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -121,6 +121,7 @@ describe('SentryReplay', () => {
     expect(replay.session.id).toBeDefined();
     expect(replay.session.spanId).toBeDefined();
     expect(replay.session.traceId).toBeDefined();
+    expect(replay.session.sequenceId).toBeDefined();
   });
 
   it('creates a new session and triggers a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {
@@ -201,6 +202,7 @@ describe('SentryReplay', () => {
 
     // Session's last activity should be updated
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP + ELAPSED);
+    expect(replay.session.sequenceId).toBe(1);
 
     // events array should be empty
     expect(replay.events).toHaveLength(0);
@@ -226,6 +228,7 @@ describe('SentryReplay', () => {
 
     // No activity has occurred, session's last activity should remain the same
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP);
+    expect(replay.session.sequenceId).toBe(1);
 
     // events array should be empty
     expect(replay.events).toHaveLength(0);
@@ -250,6 +253,7 @@ describe('SentryReplay', () => {
     expect(replay).not.toHaveSentReplay();
 
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP + 16000);
+    expect(replay.session.sequenceId).toBe(1);
     // events array should be empty
     expect(replay.events).toHaveLength(0);
 

--- a/src/session/createSession.test.ts
+++ b/src/session/createSession.test.ts
@@ -15,7 +15,7 @@ it('creates a new session with no sticky sessions', function () {
 
   expect(Sentry.getCurrentHub().startTransaction).toHaveBeenCalledWith({
     name: 'sentry-replay',
-    tags: { isReplayRoot: 'yes' },
+    tags: { isReplayRoot: 'yes', sequenceId: 0 },
   });
 
   expect(saveSession).not.toHaveBeenCalled();
@@ -32,11 +32,12 @@ it('creates a new session with sticky sessions', function () {
 
   expect(Sentry.getCurrentHub().startTransaction).toHaveBeenCalledWith({
     name: 'sentry-replay',
-    tags: { isReplayRoot: 'yes' },
+    tags: { isReplayRoot: 'yes', sequenceId: 0 },
   });
 
   expect(saveSession).toHaveBeenCalledWith({
     id: 'transaction_id',
+    sequenceId: 0,
     traceId: 'trace_id',
     spanId: 'span_id',
     started: expect.any(Number),

--- a/src/session/createSession.ts
+++ b/src/session/createSession.ts
@@ -27,6 +27,7 @@ export function createSession({
     name: ROOT_REPLAY_NAME,
     tags: {
       isReplayRoot: 'yes',
+      sequenceId: 0,
     },
   });
 
@@ -43,6 +44,7 @@ export function createSession({
     traceId: transaction.traceId,
     started: currentDate,
     lastActivity: currentDate,
+    sequenceId: 0,
   };
 
   if (stickySession) {

--- a/src/session/getSession.test.ts
+++ b/src/session/getSession.test.ts
@@ -9,6 +9,7 @@ function createMockSession(when: number = new Date().getTime()) {
   return {
     id: 'transaction_id',
     traceId: 'trace_id',
+    sequenceId: 0,
     spanId: 'span_id',
     lastActivity: when,
     started: when,
@@ -37,6 +38,7 @@ it('creates a non-sticky session when one does not exist', function () {
     id: 'transaction_id',
     traceId: 'trace_id',
     spanId: 'span_id',
+    sequenceId: 0,
     lastActivity: expect.any(Number),
     started: expect.any(Number),
   });
@@ -68,6 +70,7 @@ it('creates a sticky session when one does not exist', function () {
     id: 'transaction_id',
     traceId: 'trace_id',
     spanId: 'span_id',
+    sequenceId: 0,
     lastActivity: expect.any(Number),
     started: expect.any(Number),
   });
@@ -77,32 +80,7 @@ it('creates a sticky session when one does not exist', function () {
     id: 'transaction_id',
     traceId: 'trace_id',
     spanId: 'span_id',
-    lastActivity: expect.any(Number),
-    started: expect.any(Number),
-  });
-});
-
-it('creates a sticky session when one does not exist', function () {
-  expect(FetchSession.fetchSession()).toBe(null);
-
-  const session = getSession({ expiry: 900000, stickySession: true });
-
-  expect(FetchSession.fetchSession).toHaveBeenCalled();
-  expect(CreateSession.createSession).toHaveBeenCalled();
-
-  expect(session).toEqual({
-    id: 'transaction_id',
-    traceId: 'trace_id',
-    spanId: 'span_id',
-    lastActivity: expect.any(Number),
-    started: expect.any(Number),
-  });
-
-  // Should not have anything in storage
-  expect(FetchSession.fetchSession()).toEqual({
-    id: 'transaction_id',
-    traceId: 'trace_id',
-    spanId: 'span_id',
+    sequenceId: 0,
     lastActivity: expect.any(Number),
     started: expect.any(Number),
   });
@@ -121,6 +99,7 @@ it('fetches an existing sticky session', function () {
     id: 'transaction_id',
     traceId: 'trace_id',
     spanId: 'span_id',
+    sequenceId: 0,
     lastActivity: now,
     started: now,
   });
@@ -140,4 +119,5 @@ it('fetches an expired sticky session', function () {
   expect(session.spanId).toBe('span_id');
   expect(session.lastActivity).toBeGreaterThanOrEqual(now);
   expect(session.started).toBeGreaterThanOrEqual(now);
+  expect(session.sequenceId).toBe(0);
 });

--- a/src/session/saveSession.test.ts
+++ b/src/session/saveSession.test.ts
@@ -14,6 +14,7 @@ it('saves a valid session', function () {
     id: 'fd09adfc4117477abc8de643e5a5798a',
     traceId: 'traceId',
     spanId: 'spanId',
+    sequenceId: 0,
     started: 1648827162630,
     lastActivity: 1648827162658,
   };

--- a/src/session/types.ts
+++ b/src/session/types.ts
@@ -4,4 +4,5 @@ export interface ReplaySession {
   spanId: string;
   started: number;
   lastActivity: number;
+  sequenceId: number;
 }

--- a/src/util/isSessionExpired.test.ts
+++ b/src/util/isSessionExpired.test.ts
@@ -7,6 +7,7 @@ function createSession(extra?: Record<string, any>) {
     traceId: 'trace',
     started: 0,
     lastActivity: 0,
+    sequenceId: 0,
     ...extra,
   };
 }


### PR DESCRIPTION
we'll be using replay_id + sequence_id as the row key for individual replay events. We keep a simple monotonically increasing counter and increment whenever we send a new replay event. note that recordings payloads don't increase / use the counter.