### PR TITLE
feat: Allow custom hub and fix `getDsn().user` deprecation

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,11 @@
 import * as Sentry from '@sentry/browser';
-import { DsnComponents, Event, Scope, Transaction } from '@sentry/types';
+import {
+  DsnComponents,
+  Event,
+  Integration,
+  Scope,
+  Transaction,
+} from '@sentry/types';
 
 import { record } from 'rrweb';
 import type { eventWithTime } from 'rrweb/typings/types';
@@ -48,7 +54,7 @@ interface SentryReplayConfiguration extends PluginOptions {
   rrwebConfig?: RRWebOptions;
 }
 
-export class SentryReplay {
+export class SentryReplay implements Integration {
   /**
    * @inheritDoc
    */
@@ -96,12 +102,12 @@ export class SentryReplay {
   session: ReplaySession | undefined;
 
   static attachmentUrlFromDsn(dsn: DsnComponents, eventId: string) {
-    const { host, projectId, protocol, user } = dsn;
+    const { host, projectId, protocol, publicKey } = dsn;
 
     const port = dsn.port !== '' ? `:${dsn.port}` : '';
     const path = dsn.path !== '' ? `/${dsn.path}` : '';
 
-    return `${protocol}://${host}${port}${path}/api/${projectId}/events/${eventId}/attachments/?sentry_key=${user}&sentry_version=7&sentry_client=replay`;
+    return `${protocol}://${host}${port}${path}/api/${projectId}/events/${eventId}/attachments/?sentry_key=${publicKey}&sentry_version=7&sentry_client=replay`;
   }
 
   constructor({


### PR DESCRIPTION
`user` field has been removed from `getDsn()` - see
https://github.com/getsentry/sentry-javascript/blob/7.x/MIGRATION.md\#custom-transports

Also allow a Sentry Hub to be passed to constructor and to be used instead
of `getCurrentHub()`. Multiple hubs are needed for us to test out the
plugin in production with replays being sent to a separate project.