### PR TITLE
fix: Fix stickySession=false causing an infinite loop

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -65,6 +65,7 @@ describe('SentryReplay', () => {
   let mockSendReplayRequest: MockSendReplayRequest;
 
   beforeAll(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
     // XXX: We can only call `Sentry.init` once, not sure how to destroy it
     // after it has been in initialized
     replay = new SentryReplay({
@@ -94,6 +95,7 @@ describe('SentryReplay', () => {
   afterEach(() => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     sessionStorage.clear();
+    replay.clearSession();
     replay.loadSession({ expiry: SESSION_IDLE_DURATION });
     mockRecord.takeFullSnapshot.mockClear();
   });
@@ -121,6 +123,235 @@ describe('SentryReplay', () => {
     });
     expect(replay.session.id).toBeDefined();
     expect(replay.session.sequenceId).toBeDefined();
+  });
+
+  it('creates a new session and triggers a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'visible';
+      },
+    });
+
+    const initialSession = replay.session;
+
+    jest.advanceTimersByTime(VISIBILITY_CHANGE_TIMEOUT + 1);
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockRecord.takeFullSnapshot).toHaveBeenLastCalledWith(true);
+
+    // Should have created a new session
+    expect(replay).not.toHaveSameSession(initialSession);
+  });
+
+  it('does not create a new session if user hides the tab and comes back within 60 seconds', () => {
+    const initialSession = replay.session;
+
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'hidden';
+      },
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay).toHaveSameSession(initialSession);
+
+    // User comes back before `VISIBILITY_CHANGE_TIMEOUT` elapses
+    jest.advanceTimersByTime(VISIBILITY_CHANGE_TIMEOUT - 1);
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'visible';
+      },
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    // Should NOT have created a new session
+    expect(replay).toHaveSameSession(initialSession);
+  });
+
+  it('uploads a replay event when document becomes hidden', () => {
+    mockRecord.takeFullSnapshot.mockClear();
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'hidden';
+      },
+    });
+
+    // Pretend 5 seconds have passed
+    const ELAPSED = 5000;
+    jest.advanceTimersByTime(ELAPSED);
+
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+    replay.events = [TEST_EVENT];
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+
+    const regex = new RegExp(
+      'https://ingest.f00.f00/api/1/events/[^/]+/attachments/\\?sentry_key=dsn&sentry_version=7&sentry_client=replay'
+    );
+    expect(replay.sendReplayRequest).toHaveBeenCalledWith({
+      endpoint: expect.stringMatching(regex),
+      events: [TEST_EVENT],
+      replaySpans: [],
+      breadcrumbs: [],
+    });
+
+    // Session's last activity should be updated
+    expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP + ELAPSED);
+    expect(replay.session.sequenceId).toBe(1);
+
+    // events array should be empty
+    expect(replay.events).toHaveLength(0);
+  });
+
+  it('uploads a replay event if 5 seconds have elapsed since the last replay event occurred', () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+    mockRecord._emitter(TEST_EVENT);
+    // Pretend 5 seconds have passed
+    const ELAPSED = 5000;
+    jest.advanceTimersByTime(ELAPSED);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+
+    const regex = new RegExp(
+      'https://ingest.f00.f00/api/1/events/[^/]+/attachments/\\?sentry_key=dsn&sentry_version=7&sentry_client=replay'
+    );
+    expect(replay.sendReplayRequest).toHaveBeenCalledWith({
+      endpoint: expect.stringMatching(regex),
+      events: [TEST_EVENT],
+      replaySpans: [],
+      breadcrumbs: [],
+    });
+
+    // No activity has occurred, session's last activity should remain the same
+    expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP);
+    expect(replay.session.sequenceId).toBe(1);
+
+    // events array should be empty
+    expect(replay.events).toHaveLength(0);
+  });
+
+  it('uploads a replay event if 15 seconds have elapsed since the last replay upload', () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    // Fire a new event every 4 seconds, 4 times
+    [...Array(4)].forEach(() => {
+      mockRecord._emitter(TEST_EVENT);
+      jest.advanceTimersByTime(4000);
+    });
+
+    // We are at time = +16seconds now (relative to BASE_TIMESTAMP)
+    // The next event should cause an upload immediately
+    mockRecord._emitter(TEST_EVENT);
+    expect(replay).toHaveSentReplay([...Array(5)].map(() => TEST_EVENT));
+
+    // There should also not be another attempt at an upload 5 seconds after the last replay event
+    mockSendReplayRequest.mockClear();
+    jest.advanceTimersByTime(5000);
+    expect(replay).not.toHaveSentReplay();
+
+    expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP + 16000);
+    expect(replay.session.sequenceId).toBe(1);
+    // events array should be empty
+    expect(replay.events).toHaveLength(0);
+
+    // Let's make sure it continues to work
+    mockSendReplayRequest.mockClear();
+    mockRecord._emitter(TEST_EVENT);
+    jest.advanceTimersByTime(5000);
+    expect(replay).toHaveSentReplay([TEST_EVENT]);
+
+    // Clean-up
+    mockSendReplayRequest.mockReset();
+  });
+
+  it('creates a new session if user has been idle for more than 15 minutes and comes back to move their mouse', () => {
+    const initialSession = replay.session;
+
+    expect(initialSession.id).toBeDefined();
+
+    // Idle for 15 minutes
+    jest.advanceTimersByTime(15 * 60000);
+
+    // TBD: We are currently deciding that this event will get dropped, but
+    // this could/should change in the future.
+    const TEST_EVENT = {
+      data: { name: 'lost event' },
+      timestamp: BASE_TIMESTAMP,
+      type: 3,
+    };
+    mockRecord._emitter(TEST_EVENT);
+    expect(replay).not.toHaveSentReplay();
+
+    // Instead of recording the above event, a full snapshot will occur.
+    //
+    // TODO: We could potentially figure out a way to save the last session,
+    // and produce a checkout based on a previous checkout + updates, and then
+    // replay the event on top. Or maybe replay the event on top of a refresh
+    // snapshot.
+    expect(mockRecord.takeFullSnapshot).toHaveBeenCalledWith(true);
+
+    expect(replay).toHaveSentReplay([
+      { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 },
+    ]);
+
+    // Should be a new session
+    expect(replay).not.toHaveSameSession(initialSession);
+
+    mockSendReplayRequest.mockReset();
+  });
+});
+
+describe('SentryReplay (no sticky)', () => {
+  let replay: SentryReplay;
+  type MockSendReplayRequest = jest.MockedFunction<
+    typeof replay.sendReplayRequest
+  >;
+  let mockSendReplayRequest: MockSendReplayRequest;
+
+  beforeAll(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    // XXX: We can only call `Sentry.init` once, not sure how to destroy it
+    // after it has been in initialized
+    replay = new SentryReplay({
+      stickySession: false,
+      rrwebConfig: { ignoreClass: 'sr-test' },
+    });
+
+    // XXX: we cannot call `Sentry.init()` again in the same test file
+    // So we have to fake the init with existing SDK client with a different plugin instance
+    replay.setup();
+
+    jest.spyOn(replay, 'sendReplayRequest');
+    mockSendReplayRequest = replay.sendReplayRequest as MockSendReplayRequest;
+    mockSendReplayRequest.mockImplementation(
+      jest.fn(async () => {
+        return;
+      })
+    );
+    jest.runAllTimers();
+  });
+
+  beforeEach(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    mockSendReplayRequest.mockClear();
+  });
+
+  afterEach(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    replay.clearSession();
+    replay.loadSession({ expiry: SESSION_IDLE_DURATION });
+    mockRecord.takeFullSnapshot.mockClear();
+  });
+
+  afterAll(() => {
+    replay && replay.teardown();
   });
 
   it('creates a new session and triggers a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -253,6 +253,10 @@ export class SentryReplay implements Integration {
     this.removeListeners();
   }
 
+  clearSession() {
+    this.session = null;
+  }
+
   /**
    * Loads a session from storage, or creates a new one
    */
@@ -260,7 +264,15 @@ export class SentryReplay implements Integration {
     this.session = getSession({
       expiry,
       stickySession: this.options.stickySession,
+      currentSession: this.session,
     });
+  }
+
+  updateSession(session: Partial<ReplaySession>) {
+    this.session = {
+      ...this.session,
+      ...session,
+    };
   }
 
   addListeners() {
@@ -344,9 +356,11 @@ export class SentryReplay implements Integration {
     // Update with current timestamp as the last session activity
     // Only updating session on visibility change to be conservative about
     // writing to session storage. This could be changed in the future.
-    updateSessionActivity({
-      stickySession: this.options.stickySession,
-    });
+    this.updateSession(
+      updateSessionActivity({
+        stickySession: this.options.stickySession,
+      })
+    );
 
     // Send replay when the page/tab becomes hidden. There is no reason to send
     // replay if it becomes visible, since no actions we care about were done
@@ -407,6 +421,10 @@ export class SentryReplay implements Integration {
    * Returns true if session is not expired, false otherwise.
    */
   checkAndHandleExpiredSession(expiry: number = SESSION_IDLE_DURATION) {
+    // if (!this.options.stickySession) {
+    // return;
+    // }
+
     const oldSessionId = this.session.id;
 
     // This will create a new session if expired, based on expiry length

--- a/src/session/getSession.test.ts
+++ b/src/session/getSession.test.ts
@@ -59,6 +59,25 @@ it('creates a non-sticky session, regardless of session existing in sessionStora
   expect(session).toBeDefined();
 });
 
+it('creates a non-sticky session, when one is expired', function () {
+  const session = getSession({
+    expiry: 1000,
+    stickySession: false,
+    currentSession: {
+      id: 'old_session_id',
+      lastActivity: new Date().getTime() - 1001,
+      started: new Date().getTime() - 1001,
+      sequenceId: 0,
+    },
+  });
+
+  expect(FetchSession.fetchSession).not.toHaveBeenCalled();
+  expect(CreateSession.createSession).toHaveBeenCalled();
+
+  expect(session).toBeDefined();
+  expect(session.id).not.toBe('old_session_id');
+});
+
 it('creates a sticky session when one does not exist', function () {
   expect(FetchSession.fetchSession()).toBe(null);
 
@@ -112,5 +131,24 @@ it('fetches an expired sticky session', function () {
   expect(session.id).toBe('test_session_id');
   expect(session.lastActivity).toBeGreaterThanOrEqual(now);
   expect(session.started).toBeGreaterThanOrEqual(now);
+  expect(session.sequenceId).toBe(0);
+});
+
+it('fetches a non-expired non-sticky session', function () {
+  const session = getSession({
+    expiry: 1000,
+    stickySession: false,
+    currentSession: {
+      id: 'test_session_id_2',
+      lastActivity: +new Date() - 500,
+      started: +new Date() - 500,
+      sequenceId: 0,
+    },
+  });
+
+  expect(FetchSession.fetchSession).not.toHaveBeenCalled();
+  expect(CreateSession.createSession).not.toHaveBeenCalled();
+
+  expect(session.id).toBe('test_session_id_2');
   expect(session.sequenceId).toBe(0);
 });

--- a/src/session/getSession.ts
+++ b/src/session/getSession.ts
@@ -2,6 +2,7 @@ import { isSessionExpired } from '@/util/isSessionExpired';
 import { logger } from '@/util/logger';
 import { createSession } from './createSession';
 import { fetchSession } from './fetchSession';
+import { ReplaySession } from './types';
 
 interface GetSessionParams {
   /**
@@ -12,13 +13,22 @@ interface GetSessionParams {
    * Should save session to sessionStorage?
    */
   stickySession: boolean;
+
+  /**
+   * The current session (e.g. if stickySession is off)
+   */
+  currentSession?: ReplaySession;
 }
 
 /**
  * Get or create a session
  */
-export function getSession({ expiry, stickySession }: GetSessionParams) {
-  const session = stickySession && fetchSession();
+export function getSession({
+  expiry,
+  currentSession,
+  stickySession,
+}: GetSessionParams) {
+  const session = stickySession ? fetchSession() : currentSession;
 
   if (session) {
     // If there is a session, check if it is valid (e.g. "last activity" time should be within the "session idle time")


### PR DESCRIPTION
When stickySession=false, it was causing all sessions to appear expired, which then triggered a full snapshot, which in turn does a session check and loops.