### PR TITLE
feat: Upload replay after receiving event from core SDK

### DIFF
--- a/src/coreHandlers/handleDom.ts
+++ b/src/coreHandlers/handleDom.ts
@@ -28,7 +28,7 @@ export function handleDom(handlerData: any) {
     message: target,
     data: {
       // Not sure why this errors, Node should be correct (Argument of type 'Node' is not assignable to parameter of type 'INode')
-      nodeId: targetNode ? record.mirror.getId(targetNode as any) : undefined,
+      ...(targetNode ? { nodeId: record.mirror.getId(targetNode as any) } : {}),
     },
   };
 }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -25,6 +25,8 @@ jest.mock('rrweb', () => {
 });
 
 import * as Sentry from '@sentry/browser';
+import * as SentryUtils from '@sentry/utils';
+import type { Breadcrumbs } from '@sentry/browser/types/integrations';
 import * as rrweb from 'rrweb';
 
 import { SentryReplay } from '@';
@@ -34,7 +36,6 @@ import {
 } from '@/session/constants';
 import { BASE_TIMESTAMP } from '@test';
 import { ReplaySpan, RRWebEvent } from '@/types';
-import { Breadcrumbs } from '@sentry/browser/types/integrations';
 
 type RecordAdditionalProperties = {
   takeFullSnapshot: jest.Mock;
@@ -56,16 +57,22 @@ const mockRecord = rrweb.record as RecordMock;
 
 jest.useFakeTimers();
 
-// TODO: tests for our breadcrumbs / spans
 describe('SentryReplay', () => {
   let replay: SentryReplay;
   type MockSendReplayRequest = jest.MockedFunction<
     typeof replay.sendReplayRequest
   >;
   let mockSendReplayRequest: MockSendReplayRequest;
+  let domHandler: (args: any) => any;
 
   beforeAll(() => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    jest
+      .spyOn(SentryUtils, 'addInstrumentationHandler')
+      .mockImplementation((_type, handler: (args: any) => any) => {
+        domHandler = handler;
+      });
+
     // XXX: We can only call `Sentry.init` once, not sure how to destroy it
     // after it has been in initialized
     replay = new SentryReplay({
@@ -305,6 +312,39 @@ describe('SentryReplay', () => {
     expect(replay).not.toHaveSameSession(initialSession);
 
     mockSendReplayRequest.mockReset();
+  });
+
+  it('uploads a dom breadcrumb 5 seconds after listener receives an event', () => {
+    domHandler({
+      name: 'click',
+    });
+
+    // Pretend 5 seconds have passed
+    const ELAPSED = 5000;
+    jest.advanceTimersByTime(ELAPSED);
+
+    const regex = new RegExp(
+      'https://ingest.f00.f00/api/1/events/[^/]+/attachments/\\?sentry_key=dsn&sentry_version=7&sentry_client=replay'
+    );
+    expect(replay.sendReplayRequest).toHaveBeenCalledWith({
+      endpoint: expect.stringMatching(regex),
+      events: [],
+      replaySpans: [],
+      breadcrumbs: [
+        {
+          timestamp: BASE_TIMESTAMP / 1000,
+          type: 'default',
+          category: `ui.click`,
+          message: '<unknown>',
+          data: {},
+        },
+      ],
+    });
+
+    expect(replay.session.sequenceId).toBe(1);
+
+    // breadcrumbs array should be empty
+    expect(replay.breadcrumbs).toHaveLength(0);
   });
 
   it('fails to upload data on first call and retries after five seconds, sending successfully', async () => {


### PR DESCRIPTION
Previously we did not create replay events after receiving new updates from core SDK (e.g. breadcrumbs) -- they only get flushed after an rrweb event.

This causes breadcrumbs to be attached to a new session instead of the previous session.

e.g. old session -> breadcrumbs -> <idle> (no upload happens)
 --> new session -> rrweb checkout -> upload (with old breadcrumbs)

 Fixes https://github.com/getsentry/sentry-replay/issues/79
