### PR TITLE
feat: Change `VISIBILITY_CHANGE_TIMEOUT` to match `SESSION_IDLE_DURATION`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -157,7 +157,7 @@ describe('SentryReplay', () => {
     });
     // Session's last activity should be updated
     expect(replay.session.lastActivity).toBeGreaterThan(BASE_TIMESTAMP);
-    // // events array should be empty
+    // events array should be empty
     expect(replay.eventBuffer.length).toBe(0);
   });
 

--- a/src/session/constants.ts
+++ b/src/session/constants.ts
@@ -2,7 +2,8 @@ export const REPLAY_SESSION_KEY = 'sentryReplaySession';
 export const ROOT_REPLAY_NAME = 'sentry-replay';
 export const REPLAY_EVENT_NAME = 'sentry-replay-event';
 
-// Grace period to keep a session when a user changes tabs or hides window
-export const VISIBILITY_CHANGE_TIMEOUT = 60000; // 1 minute
 // The idle limit for a session
 export const SESSION_IDLE_DURATION = 900000; // 15 minutes
+
+// Grace period to keep a session when a user changes tabs or hides window
+export const VISIBILITY_CHANGE_TIMEOUT = SESSION_IDLE_DURATION;


### PR DESCRIPTION
We are noticing a lot of short sessions that I suspect is related to the visibility change timeout. Keeping the code around and changing the constants in case we decide to tweak this later.
