### PR TITLE
feat: Only capture replays when errors happen

### DIFF
--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -1,0 +1,207 @@
+jest.unmock('@sentry/browser');
+
+// mock functions need to be imported first
+import { captureException } from '@sentry/browser';
+import { BASE_TIMESTAMP, mockSdk, mockRrweb } from '@test';
+
+import { SentryReplay } from '@';
+import {
+  SESSION_IDLE_DURATION,
+  VISIBILITY_CHANGE_TIMEOUT,
+} from '@/session/constants';
+
+jest.useFakeTimers({ advanceTimers: true });
+
+async function advanceTimers(time: number) {
+  jest.advanceTimersByTime(time);
+  await new Promise(process.nextTick);
+}
+
+describe('SentryReplay (capture only on error)', () => {
+  let replay: SentryReplay;
+  type MockSendReplayRequest = jest.MockedFunction<
+    typeof replay.sendReplayRequest
+  >;
+  let mockSendReplayRequest: MockSendReplayRequest;
+  const { record: mockRecord } = mockRrweb();
+
+  beforeAll(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    ({ replay } = mockSdk({
+      replayOptions: { captureOnlyOnError: true, stickySession: false },
+    }));
+    jest.spyOn(replay, 'sendReplayRequest');
+    mockSendReplayRequest = replay.sendReplayRequest as MockSendReplayRequest;
+    mockSendReplayRequest.mockImplementation(
+      jest.fn(async () => {
+        return;
+      })
+    );
+    jest.runAllTimers();
+  });
+
+  beforeEach(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    mockSendReplayRequest.mockClear();
+    mockRecord.takeFullSnapshot.mockClear();
+  });
+
+  afterEach(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    replay.clearSession();
+    replay.loadSession({ expiry: SESSION_IDLE_DURATION });
+  });
+
+  afterAll(() => {
+    replay && replay.destroy();
+  });
+
+  it('uploads a replay when captureException is called', async () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+    mockRecord._emitter(TEST_EVENT);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay).not.toHaveSentReplay();
+
+    // TODO: captureException(new Error('testing')) does not trigger addGlobalEventProcessor
+    captureException('testing');
+
+    await new Promise(process.nextTick);
+    await new Promise(process.nextTick);
+    expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));
+  });
+
+  it('does not send a replay when triggering a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'visible';
+      },
+    });
+
+    jest.advanceTimersByTime(VISIBILITY_CHANGE_TIMEOUT + 1);
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(replay).not.toHaveSentReplay();
+  });
+
+  it('does not send a replay if user hides the tab and comes back within 60 seconds', () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'hidden';
+      },
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+    expect(replay).not.toHaveSentReplay();
+
+    // User comes back before `VISIBILITY_CHANGE_TIMEOUT` elapses
+    jest.advanceTimersByTime(VISIBILITY_CHANGE_TIMEOUT - 1);
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'visible';
+      },
+    });
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay).not.toHaveSentReplay();
+  });
+
+  it('does not upload a replay event when document becomes hidden', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'hidden';
+      },
+    });
+
+    // Pretend 5 seconds have passed
+    const ELAPSED = 5000;
+    jest.advanceTimersByTime(ELAPSED);
+
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+    replay.eventBuffer.addEvent(TEST_EVENT);
+
+    document.dispatchEvent(new Event('visibilitychange'));
+
+    await new Promise(process.nextTick);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+
+    expect(replay).not.toHaveSentReplay();
+  });
+
+  it('does not upload a replay event if 5 seconds have elapsed since the last replay event occurred', async () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    mockRecord._emitter(TEST_EVENT);
+    // Pretend 5 seconds have passed
+    const ELAPSED = 5000;
+    await advanceTimers(ELAPSED);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+
+    expect(replay).not.toHaveSentReplay();
+  });
+
+  it('does not upload a replay event if 15 seconds have elapsed since the last replay upload', async () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    // Fire a new event every 4 seconds, 4 times
+    [...Array(4)].forEach(() => {
+      mockRecord._emitter(TEST_EVENT);
+      jest.advanceTimersByTime(4000);
+    });
+
+    // We are at time = +16seconds now (relative to BASE_TIMESTAMP)
+    // The next event should cause an upload immediately
+    mockRecord._emitter(TEST_EVENT);
+    await new Promise(process.nextTick);
+
+    expect(replay).not.toHaveSentReplay();
+
+    // There should also not be another attempt at an upload 5 seconds after the last replay event
+    mockSendReplayRequest.mockClear();
+    await advanceTimers(5000);
+    expect(replay).not.toHaveSentReplay();
+
+    // Let's make sure it continues to work
+    mockSendReplayRequest.mockClear();
+    mockRecord._emitter(TEST_EVENT);
+    await advanceTimers(5000);
+    expect(replay).not.toHaveSentReplay();
+
+    // Clean-up
+    mockSendReplayRequest.mockReset();
+  });
+
+  it('does not upload if user has been idle for more than 15 minutes and comes back to move their mouse', async () => {
+    // Idle for 15 minutes
+    jest.advanceTimersByTime(15 * 60000);
+
+    // TBD: We are currently deciding that this event will get dropped, but
+    // this could/should change in the future.
+    const TEST_EVENT = {
+      data: { name: 'lost event' },
+      timestamp: BASE_TIMESTAMP,
+      type: 3,
+    };
+    mockRecord._emitter(TEST_EVENT);
+    expect(replay).not.toHaveSentReplay();
+
+    await new Promise(process.nextTick);
+
+    // Instead of recording the above event, a full snapshot will occur.
+    //
+    // TODO: We could potentially figure out a way to save the last session,
+    // and produce a checkout based on a previous checkout + updates, and then
+    // replay the event on top. Or maybe replay the event on top of a refresh
+    // snapshot.
+
+    expect(replay).not.toHaveSentReplay();
+    expect(mockRecord.takeFullSnapshot).toHaveBeenCalledWith(true);
+
+    mockSendReplayRequest.mockReset();
+  });
+});

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -191,6 +191,7 @@ describe('SentryReplay', () => {
     replay.eventBuffer.addEvent(TEST_EVENT);
     window.dispatchEvent(new Event('blur'));
     await new Promise(process.nextTick);
+    await new Promise(process.nextTick);
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
     expect(replay.sendReplayRequest).toHaveBeenCalled();
     expect(replay).toHaveSentReplay(

--- a/src/index.ts
+++ b/src/index.ts
@@ -148,9 +148,9 @@ export class SentryReplay implements Integration {
       captureOnlyOnError,
     };
 
-    // Modify rrweb options to checkoutEveryNthSecond if this is defined, as we don't know when an error occurs, so we want to try to minimize
+    // Modify rrweb options to checkoutEveryNthSecond if this is defined, as we don't know when an error occurs, so we want to try to minimize the number of events captured.
     if (this.options.captureOnlyOnError) {
-      // Checkout every minute, meaning we only get the last minute of events before the error happens
+      // Checkout every minute, meaning we only get up-to one minute of events before the error happens
       this.rrwebRecordOptions.checkoutEveryNms = 60000;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -391,7 +391,7 @@ export class SentryReplay implements Integration {
     // Do not apply replayId to the root event
     if (
       event.message === ROOT_REPLAY_NAME ||
-      event.message.startsWith(REPLAY_EVENT_NAME)
+      event.message?.startsWith(REPLAY_EVENT_NAME)
     ) {
       return event;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -399,10 +399,10 @@ export class SentryReplay implements Integration {
     event.tags = { ...event.tags, replayId: this.session.id };
 
     // Need to be very careful that this does not cause an infinite loop
-    if (event.exception) {
-      // XXX: Do we continue to record after?
+    if (this.options.captureOnlyOnError && event.exception) {
+      // TODO: Do we continue to record after?
       // TODO: What happens if another error happens? Do we record in the same session?
-      setTimeout(() => this.conditionalFlush());
+      setTimeout(() => this.flushUpdate());
     }
 
     return event;
@@ -666,7 +666,7 @@ export class SentryReplay implements Integration {
    * Only flush if `captureOnlyOnError` is false.
    */
   conditionalFlush(lastActivity?: number) {
-    if (!this.options.captureOnlyOnError) {
+    if (this.options.captureOnlyOnError) {
       return;
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -64,6 +64,11 @@ export interface SentryReplayPluginOptions {
    * (default is true)
    */
   useCompression?: boolean;
+
+  /**
+   * Only capture replays when an error happens
+   */
+  captureOnlyOnError?: boolean;
 }
 
 export interface SentryReplayConfiguration extends SentryReplayPluginOptions {


### PR DESCRIPTION
This restores a previous functionality where we capture replays only when errors happen.
