### PR TITLE
feat: Remove breadcrumb from "visibilitychange" event

### DIFF
--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -52,9 +52,6 @@ describe('SentryReplay (no sticky)', () => {
   });
 
   it('creates a new session and triggers a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {
-    // @ts-expect-error private member
-    replay.isActive = false;
-
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: function () {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -55,8 +55,6 @@ describe('SentryReplay', () => {
     replay.clearSession();
     replay.loadSession({ expiry: SESSION_IDLE_DURATION });
     mockRecord.takeFullSnapshot.mockClear();
-    // @ts-expect-error private property
-    replay.isActive = true;
   });
 
   afterAll(() => {
@@ -85,9 +83,6 @@ describe('SentryReplay', () => {
   });
 
   it('creates a new session and triggers a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {
-    // @ts-expect-error private member
-    replay.isActive = false;
-
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: function () {
@@ -108,9 +103,6 @@ describe('SentryReplay', () => {
   });
 
   it('creates a new session and triggers a full dom snapshot when document becomes focused after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {
-    // @ts-expect-error private member
-    replay.isActive = false;
-
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -93,11 +93,6 @@ export class SentryReplay implements Integration {
   private retryCount = 0;
   private retryInterval = BASE_RETRY_INTERVAL;
 
-  /**
-   * If current browser window in an active state
-   */
-  private isActive = true;
-
   session: Session | undefined;
 
   static attachmentUrlFromDsn(dsn: DsnComponents, eventId: string) {
@@ -434,13 +429,6 @@ export class SentryReplay implements Integration {
   doChangeToBackgroundTasks(breadcrumb?: Breadcrumb) {
     const isExpired = isSessionExpired(this.session, VISIBILITY_CHANGE_TIMEOUT);
 
-    // We check current state to make sure that we do nothing if the page is already inactive
-    if (!this.isActive) {
-      return;
-    }
-
-    this.isActive = false;
-
     if (breadcrumb) {
       this.createCustomBreadcrumb({
         ...breadcrumb,
@@ -462,14 +450,6 @@ export class SentryReplay implements Integration {
    */
   doChangeToForegroundTasks(breadcrumb?: Breadcrumb) {
     const isExpired = isSessionExpired(this.session, VISIBILITY_CHANGE_TIMEOUT);
-
-    // No need to do anything if page is already active (from focus event or
-    // page visibility)
-    if (this.isActive) {
-      return;
-    }
-
-    this.isActive = true;
 
     if (breadcrumb) {
       this.createCustomBreadcrumb({


### PR DESCRIPTION
We're going to axe the "visible" breadcrumb, as it is a point of confusion for users (i.e. what is the difference between blur/focus and visibility?) We will be able to get the information we need with focus/blur alone.