### PR TITLE
feat: Defer capturing root replay until upload

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -433,9 +433,8 @@ describe('SentryReplay', () => {
     replay.eventBuffer.addEvent(TEST_EVENT);
     window.dispatchEvent(new Event('blur'));
     await new Promise(process.nextTick);
-    // const ELAPSED = 5000;
-    // jest.advanceTimersByTime(ELAPSED);
     expect(replay.sendReplayRequest).toHaveBeenCalled();
     expect(captureReplayMock).not.toHaveBeenCalled();
+    expect(replay.session.sequenceId).toBe(2);
   });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -434,7 +434,7 @@ describe('SentryReplay', () => {
     expect(replay.session.sequenceId).toBe(2);
   });
 
-  it('does not create root event unless there are events to send', async () => {
+  it('does not create root event when there are no events to send', async () => {
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: function () {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -437,4 +437,21 @@ describe('SentryReplay', () => {
     expect(captureReplayMock).not.toHaveBeenCalled();
     expect(replay.session.sequenceId).toBe(2);
   });
+
+  it('does not create root event unless there are events to send', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'hidden';
+      },
+    });
+
+    // Pretend 5 seconds have passed
+    const ELAPSED = 5000;
+    jest.advanceTimersByTime(ELAPSED);
+    document.dispatchEvent(new Event('visibilitychange'));
+    await new Promise(process.nextTick);
+    expect(replay.sendReplayRequest).not.toHaveBeenCalled();
+    expect(captureReplayMock).not.toHaveBeenCalled();
+  });
 });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,7 +1,6 @@
 // mock functions need to be imported first
 import { BASE_TIMESTAMP, mockSdk, mockRrweb } from '@test';
 
-import * as Sentry from '@sentry/browser';
 import * as SentryUtils from '@sentry/utils';
 import * as CaptureReplay from '@/api/captureReplay';
 
@@ -10,9 +9,6 @@ import {
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
 } from '@/session/constants';
-import { captureReplay } from './api/captureReplay';
-
-type captureEventMockType = jest.MockedFunction<typeof Sentry.captureEvent>;
 
 jest.useFakeTimers({ advanceTimers: true });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -625,7 +625,6 @@ export class SentryReplay implements Integration {
       this.shouldCreateReplay = false;
     }
 
-    // TEMP: keep sending a replay event just for the duration
     captureEvent({
       message: `${REPLAY_EVENT_NAME}-${uuid4().substring(16)}`,
       tags: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -596,15 +596,6 @@ export class SentryReplay implements Integration {
       return;
     }
 
-    // TEMP: keep sending a replay event just for the duration
-    captureEvent({
-      message: `${REPLAY_EVENT_NAME}-${uuid4().substring(16)}`,
-      tags: {
-        replayId: this.session.id,
-        sequenceId: this.session.sequenceId++,
-      },
-    });
-
     this.addPerformanceEntries();
     const recordingData = await this.eventBuffer.finish();
     this.sendReplay(this.session.id, recordingData);
@@ -617,6 +608,15 @@ export class SentryReplay implements Integration {
       captureReplay(this.session);
       this.hasSentReplay = true;
     }
+
+    // TEMP: keep sending a replay event just for the duration
+    captureEvent({
+      message: `${REPLAY_EVENT_NAME}-${uuid4().substring(16)}`,
+      tags: {
+        replayId: this.session.id,
+        sequenceId: this.session.sequenceId++,
+      },
+    });
   }
 
   /**

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -22,7 +22,6 @@ interface SessionObject {
 
 interface SessionOptions {
   stickySession?: boolean;
-  isNew?: boolean;
 }
 
 export class Session {
@@ -46,11 +45,11 @@ export class Session {
    */
   private _sequenceId;
 
-  public options: Required<SessionOptions>;
+  public readonly options: Required<SessionOptions>;
 
   constructor(
     session: Partial<SessionObject> = {},
-    { stickySession = false, isNew = true }: SessionOptions = {}
+    { stickySession = false }: SessionOptions = {}
   ) {
     const now = new Date().getTime();
     this._id = session.id || uuid4();
@@ -60,7 +59,6 @@ export class Session {
 
     this.options = {
       stickySession,
-      isNew,
     };
   }
 

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -22,6 +22,7 @@ interface SessionObject {
 
 interface SessionOptions {
   stickySession?: boolean;
+  isNew?: boolean;
 }
 
 export class Session {
@@ -45,11 +46,11 @@ export class Session {
    */
   private _sequenceId;
 
-  private options: Record<string, any>;
+  public options: Required<SessionOptions>;
 
   constructor(
     session: Partial<SessionObject> = {},
-    { stickySession = false }: SessionOptions = {}
+    { stickySession = false, isNew = true }: SessionOptions = {}
   ) {
     const now = new Date().getTime();
     this._id = session.id || uuid4();
@@ -59,6 +60,7 @@ export class Session {
 
     this.options = {
       stickySession,
+      isNew,
     };
   }
 

--- a/src/session/createSession.test.ts
+++ b/src/session/createSession.test.ts
@@ -2,8 +2,6 @@ import * as Sentry from '@sentry/core';
 import { createSession } from './createSession';
 import { saveSession } from './saveSession';
 
-type captureEventMockType = jest.MockedFunction<typeof Sentry.captureEvent>;
-
 jest.mock('./saveSession');
 
 jest.mock('@sentry/utils', () => {
@@ -29,10 +27,7 @@ afterEach(() => {
 
 it('creates a new session with no sticky sessions', function () {
   const newSession = createSession({ stickySession: false });
-  expect(captureEventMock).toHaveBeenCalledWith(
-    { message: 'sentry-replay', tags: { sequenceId: 0 } },
-    { event_id: 'test_session_id' }
-  );
+  expect(captureEventMock).not.toHaveBeenCalled();
 
   expect(saveSession).not.toHaveBeenCalled();
 
@@ -43,10 +38,7 @@ it('creates a new session with no sticky sessions', function () {
 
 it('creates a new session with sticky sessions', function () {
   const newSession = createSession({ stickySession: true });
-  expect(captureEventMock).toHaveBeenCalledWith(
-    { message: 'sentry-replay', tags: { sequenceId: 0 } },
-    { event_id: 'test_session_id' }
-  );
+  expect(captureEventMock).not.toHaveBeenCalled();
 
   expect(saveSession).toHaveBeenCalledWith(
     expect.objectContaining({

--- a/src/session/createSession.test.ts
+++ b/src/session/createSession.test.ts
@@ -11,6 +11,8 @@ jest.mock('@sentry/utils', () => {
   };
 });
 
+type captureEventMockType = jest.MockedFunction<typeof Sentry.captureEvent>;
+
 const captureEventMock: captureEventMockType = jest.fn();
 
 beforeAll(() => {

--- a/src/session/createSession.ts
+++ b/src/session/createSession.ts
@@ -20,7 +20,6 @@ export function createSession({
   stickySession = false,
 }: CreateSessionParams): Session {
   const session = new Session(undefined, { stickySession });
-  captureReplay(session);
 
   logger.log(`Creating new session: ${session.id}`);
 

--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -16,7 +16,7 @@ export function fetchSession(): Session | null {
       JSON.parse(window.sessionStorage.getItem(REPLAY_SESSION_KEY)),
       // We are assuming that if there is a saved item, then the session is sticky,
       // however this could break down if we used a different storage mechanism (e.g. localstorage)
-      { stickySession: true, isNew: false }
+      { stickySession: true }
     );
   } catch {
     return null;

--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -1,6 +1,9 @@
 import { REPLAY_SESSION_KEY } from './constants';
 import { Session } from './Session';
 
+/**
+ * Fetches a session from storage
+ */
 export function fetchSession(): Session | null {
   const hasSessionStorage = 'sessionStorage' in window;
 

--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -13,7 +13,7 @@ export function fetchSession(): Session | null {
       JSON.parse(window.sessionStorage.getItem(REPLAY_SESSION_KEY)),
       // We are assuming that if there is a saved item, then the session is sticky,
       // however this could break down if we used a different storage mechanism (e.g. localstorage)
-      { stickySession: true }
+      { stickySession: true, isNew: false }
     );
   } catch {
     return null;

--- a/src/session/getSession.test.ts
+++ b/src/session/getSession.test.ts
@@ -33,7 +33,7 @@ afterEach(() => {
 });
 
 it('creates a non-sticky session when one does not exist', function () {
-  const session = getSession({ expiry: 900000, stickySession: false });
+  const { session } = getSession({ expiry: 900000, stickySession: false });
 
   expect(FetchSession.fetchSession).not.toHaveBeenCalled();
   expect(CreateSession.createSession).toHaveBeenCalled();
@@ -52,7 +52,7 @@ it('creates a non-sticky session when one does not exist', function () {
 it('creates a non-sticky session, regardless of session existing in sessionStorage', function () {
   saveSession(createMockSession(new Date().getTime() - 10000));
 
-  const session = getSession({ expiry: 1000, stickySession: false });
+  const { session } = getSession({ expiry: 1000, stickySession: false });
 
   expect(FetchSession.fetchSession).not.toHaveBeenCalled();
   expect(CreateSession.createSession).toHaveBeenCalled();
@@ -61,7 +61,7 @@ it('creates a non-sticky session, regardless of session existing in sessionStora
 });
 
 it('creates a non-sticky session, when one is expired', function () {
-  const session = getSession({
+  const { session } = getSession({
     expiry: 1000,
     stickySession: false,
     currentSession: new Session({
@@ -82,7 +82,7 @@ it('creates a non-sticky session, when one is expired', function () {
 it('creates a sticky session when one does not exist', function () {
   expect(FetchSession.fetchSession()).toBe(null);
 
-  const session = getSession({ expiry: 900000, stickySession: true });
+  const { session } = getSession({ expiry: 900000, stickySession: true });
 
   expect(FetchSession.fetchSession).toHaveBeenCalled();
   expect(CreateSession.createSession).toHaveBeenCalled();
@@ -107,7 +107,7 @@ it('fetches an existing sticky session', function () {
   const now = new Date().getTime();
   saveSession(createMockSession(now));
 
-  const session = getSession({ expiry: 1000, stickySession: true });
+  const { session } = getSession({ expiry: 1000, stickySession: true });
 
   expect(FetchSession.fetchSession).toHaveBeenCalled();
   expect(CreateSession.createSession).not.toHaveBeenCalled();
@@ -124,7 +124,7 @@ it('fetches an expired sticky session', function () {
   const now = new Date().getTime();
   saveSession(createMockSession(new Date().getTime() - 2000));
 
-  const session = getSession({ expiry: 1000, stickySession: true });
+  const { session } = getSession({ expiry: 1000, stickySession: true });
 
   expect(FetchSession.fetchSession).toHaveBeenCalled();
   expect(CreateSession.createSession).toHaveBeenCalled();
@@ -136,7 +136,7 @@ it('fetches an expired sticky session', function () {
 });
 
 it('fetches a non-expired non-sticky session', function () {
-  const session = getSession({
+  const { session } = getSession({
     expiry: 1000,
     stickySession: false,
     currentSession: new Session({

--- a/src/session/getSession.ts
+++ b/src/session/getSession.ts
@@ -37,15 +37,6 @@ export function getSession({
 
     if (!isExpired) {
       logger.log(`Using existing session: ${session.id}`);
-
-      // we want to preserve the `isNew` option from currentSession, as all
-      // sessions returned from `fetchSession()` will not be considered new.
-      // however, it's possible that `getSession` is called multiple times
-      // before a root replay is created, meaning we will end up having a
-      // session where isNew is false and not having a root session created.
-      if (currentSession) {
-        session.options.isNew = currentSession.options.isNew;
-      }
       return session;
     } else {
       logger.log(`Session has expired`);

--- a/src/session/getSession.ts
+++ b/src/session/getSession.ts
@@ -37,6 +37,15 @@ export function getSession({
 
     if (!isExpired) {
       logger.log(`Using existing session: ${session.id}`);
+
+      // we want to preserve the `isNew` option from currentSession, as all
+      // sessions returned from `fetchSession()` will not be considered new.
+      // however, it's possible that `getSession` is called multiple times
+      // before a root replay is created, meaning we will end up having a
+      // session where isNew is false and not having a root session created.
+      if (currentSession) {
+        session.options.isNew = currentSession.options.isNew;
+      }
       return session;
     } else {
       logger.log(`Session has expired`);

--- a/src/session/getSession.ts
+++ b/src/session/getSession.ts
@@ -37,7 +37,7 @@ export function getSession({
 
     if (!isExpired) {
       logger.log(`Using existing session: ${session.id}`);
-      return session;
+      return { type: 'saved', session };
     } else {
       logger.log(`Session has expired`);
     }
@@ -46,5 +46,5 @@ export function getSession({
 
   const newSession = createSession({ stickySession });
 
-  return newSession;
+  return { type: 'new', session: newSession };
 }


### PR DESCRIPTION
I suspect we have a lot of "empty" replays due to this issue where we are immediately creating the root replay event. This had the possibility of having a replay w/ no recording events. Unfortunately, after some testing, a lot of short replays still get through because we immediately flush updates after a full DOM checkout. However, this is still needed in order to implement #101.