### PR TITLE
ref: Upgrade and clean-up `@sentry` SDK deps/imports

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@rollup/plugin-replace": "^4.0.0",
     "@rollup/plugin-typescript": "^8.3.1",
-    "@sentry/types": "7.0.0",
+    "@sentry/browser": "^7.7.0",
     "@types/jest": "^28.1.1",
     "@types/node": "^16.0.0",
     "@types/pako": "^2.0.0",
@@ -61,9 +61,9 @@
     "typescript": "^4.6.2"
   },
   "dependencies": {
-    "@sentry/browser": ">=6.18.2",
-    "@sentry/hub": "^7.0.0",
-    "@sentry/utils": "^7.0.0",
+    "@sentry/core": "^7.7.0",
+    "@sentry/types": "^7.7.0",
+    "@sentry/utils": "^7.7.0",
     "pako": "^2.0.4",
     "rrweb": "^1.1.3"
   },

--- a/src/api/captureReplay.ts
+++ b/src/api/captureReplay.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/browser';
+import { getCurrentHub } from '@sentry/core';
 
 import { ROOT_REPLAY_NAME } from '@/session/constants';
 import type { Session } from '@/session/Session';

--- a/src/coreHandlers/handleScope-unit.test.ts
+++ b/src/coreHandlers/handleScope-unit.test.ts
@@ -1,6 +1,6 @@
 import * as HandleScope from './handleScope';
 import { mockSdk } from '@test';
-import { getCurrentHub } from '@sentry/browser';
+import { getCurrentHub } from '@sentry/core';
 
 let mockHandleScope: jest.MockedFunction<typeof HandleScope.handleScope>;
 

--- a/src/coreHandlers/handleScope.test.ts
+++ b/src/coreHandlers/handleScope.test.ts
@@ -1,5 +1,4 @@
-import { Scope } from '@sentry/hub';
-import { Breadcrumb } from '@sentry/types';
+import { Scope, Breadcrumb } from '@sentry/types';
 import * as HandleScope from './handleScope';
 
 jest.spyOn(HandleScope, 'handleScope');

--- a/src/coreHandlers/handleScope.ts
+++ b/src/coreHandlers/handleScope.ts
@@ -1,6 +1,5 @@
 import createBreadcrumb from '@/util/createBreadcrumb';
-import { Scope } from '@sentry/hub';
-import { Breadcrumb } from '@sentry/types';
+import { Scope, Breadcrumb } from '@sentry/types';
 
 let _LAST_BREADCRUMB: null | Breadcrumb = null;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,8 @@
-import * as Sentry from '@sentry/browser';
-import { captureEvent } from '@sentry/browser';
+import {
+  addGlobalEventProcessor,
+  captureEvent,
+  getCurrentHub,
+} from '@sentry/core';
 import { addInstrumentationHandler, uuid4 } from '@sentry/utils';
 import { DsnComponents, Event, Integration, Breadcrumb } from '@sentry/types';
 
@@ -153,7 +156,7 @@ export class SentryReplay implements Integration {
 
     // Tag all (non replay) events that get sent to Sentry with the current
     // replay ID so that we can reference them later in the UI
-    Sentry.addGlobalEventProcessor((event: Event) => {
+    addGlobalEventProcessor((event: Event) => {
       // Do not apply replayId to the root event
       if (event.message === ROOT_REPLAY_NAME) {
         return event;
@@ -275,7 +278,7 @@ export class SentryReplay implements Integration {
     window.addEventListener('beforeunload', this.handleWindowUnload);
 
     // Listeners from core SDK //
-    const scope = Sentry.getCurrentHub().getScope();
+    const scope = getCurrentHub().getScope();
     scope.addScopeListener(this.handleCoreListener('scope'));
     addInstrumentationHandler('dom', this.handleCoreListener('dom'));
 
@@ -653,7 +656,7 @@ export class SentryReplay implements Integration {
       return;
     }
 
-    const client = Sentry.getCurrentHub().getClient();
+    const client = getCurrentHub().getClient();
     const endpoint = SentryReplay.attachmentUrlFromDsn(
       client.getDsn(),
       eventId

--- a/src/session/createSession.ts
+++ b/src/session/createSession.ts
@@ -1,7 +1,8 @@
 import { logger } from '@/util/logger';
+import { captureReplay } from '@/api/captureReplay';
+
 import { saveSession } from './saveSession';
 import { Session } from './Session';
-import { captureReplay } from '@/api/captureReplay';
 
 interface CreateSessionParams {
   /**

--- a/src/util/isIngestHost.ts
+++ b/src/util/isIngestHost.ts
@@ -1,4 +1,4 @@
-import { getCurrentHub } from '@sentry/browser';
+import { getCurrentHub } from '@sentry/core';
 
 /**
  * Checks is `targetHost` is a Sentry ingestion host

--- a/yarn.lock
+++ b/yarn.lock
@@ -517,18 +517,6 @@
     slash "^3.0.0"
     write-file-atomic "^4.0.1"
 
-"@jest/types@^28.1.0":
-  version "28.1.0"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.0.tgz#508327a89976cbf9bd3e1cc74641a29fd7dfd519"
-  integrity sha512-xmEggMPr317MIOjjDoZ4ejCSr9Lpbt/u34+dvc99t7DS8YirW5rwZEhzKPC2BMUFkUhI48qs6qLUSGw5FuL0GA==
-  dependencies:
-    "@jest/schemas" "^28.0.2"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.8"
-    chalk "^4.0.0"
-
 "@jest/types@^28.1.1":
   version "28.1.1"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-28.1.1.tgz#d059bbc80e6da6eda9f081f293299348bd78ee0b"
@@ -647,46 +635,46 @@
     estree-walker "^1.0.1"
     picomatch "^2.2.2"
 
-"@sentry/browser@>=6.18.2":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.0.0.tgz#c26517d9e88215494cf3a196903eafe64170f494"
-  integrity sha512-XJeQA/CIocrmShpfVcccJ2RvZbWZy+OustSbgLP5Vk+ZnzbqKQo1zQ92jO/dUoVIsl5dWpUaOKfT6gXmORf4vQ==
+"@sentry/browser@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/browser/-/browser-7.7.0.tgz#7810ee98d4969bd0367e29ac0af6c5779db7e6c4"
+  integrity sha512-oyzpWcsjVZTaf14zAL89Ng1DUHlbjN+V8pl8dR9Y9anphbzL5BK9p0fSK4kPIrO4GukK+XrKnLJDPuE/o7WR3g==
   dependencies:
-    "@sentry/core" "7.0.0"
-    "@sentry/types" "7.0.0"
-    "@sentry/utils" "7.0.0"
+    "@sentry/core" "7.7.0"
+    "@sentry/types" "7.7.0"
+    "@sentry/utils" "7.7.0"
     tslib "^1.9.3"
 
-"@sentry/core@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.0.0.tgz#8514aad3ad81ce018e1d4a956407530a8c1286d0"
-  integrity sha512-Wl7MjmahLhuzzByYiWaYTeHKQfF6usnMp+rTTYTBbneuM4MD7TikRt6ybgnxqyqR7nI7ADH/U8OljtiqwnsOcw==
+"@sentry/core@7.7.0", "@sentry/core@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/core/-/core-7.7.0.tgz#1a2d477897552d179380f7c54c7d81a4e98ea29a"
+  integrity sha512-Z15ACiuiFINFcK4gbMrnejLn4AVjKBPJOWKrrmpIe8mh+Y9diOuswt5mMUABs+jhpZvqht3PBLLGBL0WMsYMYA==
   dependencies:
-    "@sentry/hub" "7.0.0"
-    "@sentry/types" "7.0.0"
-    "@sentry/utils" "7.0.0"
+    "@sentry/hub" "7.7.0"
+    "@sentry/types" "7.7.0"
+    "@sentry/utils" "7.7.0"
     tslib "^1.9.3"
 
-"@sentry/hub@7.0.0", "@sentry/hub@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.0.0.tgz#9ffcea4ae497d9e8440683bdc72eb4b30f20d24d"
-  integrity sha512-my4s+SPZiL6BKOK89YNk74QFRejlwVKKSetzz+Wr1cxDLbGXOIHS3uRJlagqOpfthhD1dq8m3WBQnabPf5JlHQ==
+"@sentry/hub@7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/hub/-/hub-7.7.0.tgz#9ad3471cf5ecaf1a9d3a3a04ca2515ffec9e2c09"
+  integrity sha512-6gydK234+a0nKhBRDdIJ7Dp42CaiW2juTiHegUVDq+482balVzbZyEAmESCmuzKJhx5BhlCElVxs/cci1NjMpg==
   dependencies:
-    "@sentry/types" "7.0.0"
-    "@sentry/utils" "7.0.0"
+    "@sentry/types" "7.7.0"
+    "@sentry/utils" "7.7.0"
     tslib "^1.9.3"
 
-"@sentry/types@7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.0.0.tgz#a564b9762a8f5573ad17259093988da09be1db23"
-  integrity sha512-im6iugKKyeOwHWiS3u+S+Ox4F6aJQ2fe76rzTDTlzdCPol4xEqYnB2kujGVVnDYrODR+qVb24ua3OsxXxwzppA==
+"@sentry/types@7.7.0", "@sentry/types@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/types/-/types-7.7.0.tgz#dd6bd3d119d7efea0e85dbaa4b17de1c22b63c7a"
+  integrity sha512-4x8O7uerSGLnYC10krHl9t8h7xXHn5FextqKYbTCXCnx2hC8D+9lz8wcbQAFo0d97wiUYqI8opmEgFVGx7c5hQ==
 
-"@sentry/utils@7.0.0", "@sentry/utils@^7.0.0":
-  version "7.0.0"
-  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.0.0.tgz#c83d0535f58457067a4156e5558223afd256b747"
-  integrity sha512-wmZNwzl1F/xCvaGX0TLz0+M+mZP8kn5woF770o2eUgXGURIuNsnSd0Vfi0nHuBJfngVeI/3+ofOJ9MH4Co4lIw==
+"@sentry/utils@7.7.0", "@sentry/utils@^7.7.0":
+  version "7.7.0"
+  resolved "https://registry.yarnpkg.com/@sentry/utils/-/utils-7.7.0.tgz#013e3097c4268a76de578494c7df999635fb0ad4"
+  integrity sha512-fD+ROSFpeJlK7bEvUT2LOW7QqgjBpXJwVISKZ0P2fuzclRC3KoB2pbZgBM4PXMMTiSzRGWhvfRRjBiBvQJBBJQ==
   dependencies:
-    "@sentry/types" "7.0.0"
+    "@sentry/types" "7.7.0"
     tslib "^1.9.3"
 
 "@sinclair/typebox@^0.23.3":
@@ -2480,19 +2468,7 @@ jest-snapshot@^28.1.1:
     pretty-format "^28.1.1"
     semver "^7.3.5"
 
-jest-util@^28.0.0:
-  version "28.1.0"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.0.tgz#d54eb83ad77e1dd441408738c5a5043642823be5"
-  integrity sha512-qYdCKD77k4Hwkose2YBEqQk7PzUf/NSE+rutzceduFveQREeH6b+89Dc9+wjX9dAwHcgdx4yedGA3FQlU/qCTA==
-  dependencies:
-    "@jest/types" "^28.1.0"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
-jest-util@^28.1.1:
+jest-util@^28.0.0, jest-util@^28.1.1:
   version "28.1.1"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-28.1.1.tgz#ff39e436a1aca397c0ab998db5a51ae2b7080d05"
   integrity sha512-FktOu7ca1DZSyhPAxgxB6hfh2+9zMoJ7aEQA759Z6p45NuO8mWcqujH+UdHlCm/V6JTWwDztM2ITCzU1ijJAfw==


### PR DESCRIPTION
* Move `@sentry/browser` to devDeps as it is only used in tests.
* Import from `@sentry/core` instead of `@sentry/browser`
* Clean up type imports from `@sentry/hub`