### PR TITLE
feat: Do not flush immediately on checkout

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -433,9 +433,7 @@ describe('SentryReplay', () => {
     expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));
 
     // No activity has occurred, session's last activity should remain the same
-    expect(replay.session.lastActivity).toBeGreaterThanOrEqual(
-      BASE_TIMESTAMP + 15000
-    );
+    expect(replay.session.lastActivity).toBeGreaterThanOrEqual(BASE_TIMESTAMP);
     expect(replay.session.sequenceId).toBe(1);
 
     // next tick should do nothing

--- a/src/index.ts
+++ b/src/index.ts
@@ -237,8 +237,8 @@ export class SentryReplay implements Integration {
    * `<flushMinDelay>` milliseconds have elapsed since the last event
    * *OR* if `<flushMaxDelay>` milliseconds have elapsed.
    *
-   * Accepts a callback to perform side-effects and returns a boolean value if we
-   * should flush events immediately
+   * Accepts a callback to perform side-effects and can additionally return a
+   * function to have full control over the flushing.
    */
   addUpdate(cb?: AddUpdateCallback) {
     const now = new Date().getTime();

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -45,6 +45,11 @@ export class Session {
    */
   private _sequenceId;
 
+  /**
+   * Previous session ID
+   */
+  private _previousSessionId: string | undefined;
+
   public readonly options: Required<SessionOptions>;
 
   constructor(
@@ -90,6 +95,14 @@ export class Session {
     if (this.options.stickySession) {
       saveSession(this);
     }
+  }
+
+  get previousSessionId() {
+    return this._previousSessionId;
+  }
+
+  set previousSessionId(id: string) {
+    this._previousSessionId = id;
   }
 
   toJSON() {

--- a/src/types.ts
+++ b/src/types.ts
@@ -41,12 +41,17 @@ export interface SentryReplayPluginOptions {
   /**
    * The amount of time to wait before sending a replay
    */
-  uploadMinDelay?: number;
+  flushMinDelay?: number;
 
   /**
    * The max amount of time to wait before sending a replay
    */
-  uploadMaxDelay?: number;
+  flushMaxDelay?: number;
+
+  /**
+   * The amount of time to buffer the initial snapshot
+   */
+  initialFlushDelay?: number;
 
   /**
    * If false, will create a new session per pageload

--- a/test/mocks/mockRrweb.ts
+++ b/test/mocks/mockRrweb.ts
@@ -1,4 +1,3 @@
-import { BASE_TIMESTAMP } from '@test';
 import { RRWebEvent } from '@/types';
 
 type RecordAdditionalProperties = {
@@ -31,7 +30,7 @@ jest.mock('rrweb', () => {
     mockRecordFn._emitter(
       {
         data: { isCheckout },
-        timestamp: BASE_TIMESTAMP,
+        timestamp: new Date().getTime(),
         type: isCheckout ? 2 : 3,
       },
       isCheckout


### PR DESCRIPTION
Change the logic for when to flush after a full snapshot checkout. Add
option `initialFlushDelay` to control when to flush.

Do NOT flush on checkout after a session has expired. It will need to
wait for additional user actions before recording the new sessions
replay.
