### PR TITLE
feat: Capture the correct timestamps and initial URL when sending events to Sentry 

### DIFF
--- a/src/api/captureReplay.ts
+++ b/src/api/captureReplay.ts
@@ -2,14 +2,16 @@ import { getCurrentHub } from '@sentry/core';
 
 import { ROOT_REPLAY_NAME } from '@/session/constants';
 import type { Session } from '@/session/Session';
+import { InitialState } from '@/types';
 
-export function captureReplay(session: Session) {
+export function captureReplay(session: Session, initialState: InitialState) {
   const hub = getCurrentHub();
 
   hub.captureEvent(
     {
       message: ROOT_REPLAY_NAME,
-      tags: { sequenceId: session.sequenceId },
+      tags: { sequenceId: session.sequenceId, url: initialState.url },
+      timestamp: initialState.timestamp,
     },
     { event_id: session.id }
   );

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -491,12 +491,30 @@ describe('SentryReplay', () => {
       },
     });
 
-    // Pretend 5 seconds have passed
-    const ELAPSED = 5000;
-    await advanceTimers(ELAPSED);
     document.dispatchEvent(new Event('visibilitychange'));
     await new Promise(process.nextTick);
     expect(replay.sendReplayRequest).not.toHaveBeenCalled();
     expect(captureReplayMock).not.toHaveBeenCalled();
+
+    // Pretend 5 seconds have passed
+    const ELAPSED = 5000;
+    await advanceTimers(ELAPSED);
+
+    const TEST_EVENT = {
+      data: {},
+      timestamp: BASE_TIMESTAMP + ELAPSED,
+      type: 2,
+    };
+
+    replay.eventBuffer.addEvent(TEST_EVENT);
+    window.dispatchEvent(new Event('blur'));
+    await new Promise(process.nextTick);
+    expect(captureReplayMock).toHaveBeenCalledWith(
+      expect.anything(), // don't care about this arg
+      expect.objectContaining({
+        timestamp: BASE_TIMESTAMP,
+        url: 'http://localhost/', // this doesn't truly test if we are capturing the right URL as we don't change URLs, but good enough
+      })
+    );
   });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,11 +22,12 @@ import {
 } from './session/constants';
 import { getSession } from './session/getSession';
 import type {
+  InstrumentationType,
+  InitialState,
   RecordingEvent,
   RecordingConfig,
   ReplaySpan,
   ReplayRequest,
-  InstrumentationType,
   SentryReplayPluginOptions,
   SentryReplayConfiguration,
 } from './types';
@@ -37,6 +38,7 @@ import { handleDom, handleScope, handleFetch, handleXhr } from './coreHandlers';
 import createBreadcrumb from './util/createBreadcrumb';
 import { Session } from './session/Session';
 import { captureReplay } from './api/captureReplay';
+import { supportsSendBeacon } from './util/supportsSendBeacon';
 
 /**
  * Returns true to return control to calling function, otherwise continue with normal batching
@@ -105,6 +107,8 @@ export class SentryReplay implements Integration {
    * immediately before sending recording)
    */
   private needsCaptureReplay = false;
+
+  private initialState: InitialState;
 
   session: Session | undefined;
 
@@ -192,6 +196,13 @@ export class SentryReplay implements Integration {
       ...this.recordingOptions,
       emit: this.handleRecordingEmit,
     });
+
+    // Otherwise, these will be captured after the first flush, which means the
+    // URL and timestamps could incorrect
+    this.initialState = {
+      timestamp: new Date().getTime(),
+      url: `${window.location.origin}${window.location.pathname}`,
+    };
   }
 
   /**
@@ -734,7 +745,7 @@ export class SentryReplay implements Integration {
     // Only want to create replay event if session is new
     if (this.needsCaptureReplay) {
       // This event needs to exist before calling `sendReplay`
-      captureReplay(this.session);
+      captureReplay(this.session, this.initialState);
       this.needsCaptureReplay = false;
     }
 
@@ -743,14 +754,20 @@ export class SentryReplay implements Integration {
     this.initialEventTimestampSinceFlush = null;
 
     try {
+      // Save the timestamp before sending replay because `captureEvent` should only be called after successfully uploading a replay
+      const timestamp = new Date().getTime();
       const recordingData = await this.eventBuffer.finish();
       await this.sendReplay(this.session.id, recordingData);
+
       // The below will only happen after successfully sending replay //
 
       // TBD: Alternatively we could update this after every rrweb event
+      // TBD: Should the last activity timestamp here be "now" (after
+      // successful upload) or before the upload?
       this.updateLastActivity(lastActivity);
 
       captureEvent({
+        timestamp,
         message: `${REPLAY_EVENT_NAME}-${uuid4().substring(16)}`,
         tags: {
           replayId: this.session.id,
@@ -760,13 +777,6 @@ export class SentryReplay implements Integration {
     } catch (err) {
       console.error(err);
     }
-  }
-
-  /**
-   * Determine if there is browser support for `navigator.sendBeacon`
-   */
-  hasSendBeacon() {
-    return 'navigator' in window && 'sendBeacon' in window.navigator;
   }
 
   /**
@@ -783,7 +793,7 @@ export class SentryReplay implements Integration {
     formData.append('rrweb', payloadBlob, `rrweb-${new Date().getTime()}.json`);
 
     // If sendBeacon is supported and payload is smol enough...
-    if (this.hasSendBeacon() && payloadBlob.size <= 65535) {
+    if (supportsSendBeacon() && payloadBlob.size <= 65535) {
       logger.log(`uploading attachment via sendBeacon()`);
       window.navigator.sendBeacon(endpoint, formData);
       return;

--- a/src/index.ts
+++ b/src/index.ts
@@ -754,17 +754,19 @@ export class SentryReplay implements Integration {
     this.initialEventTimestampSinceFlush = null;
 
     try {
-      // Save the timestamp before sending replay because `captureEvent` should only be called after successfully uploading a replay
-      const timestamp = new Date().getTime();
+      // Save the timestamp before sending replay because `captureEvent` should
+      // only be called after successfully uploading a replay
+      const timestamp = lastActivity ?? new Date().getTime();
       const recordingData = await this.eventBuffer.finish();
       await this.sendReplay(this.session.id, recordingData);
 
       // The below will only happen after successfully sending replay //
 
       // TBD: Alternatively we could update this after every rrweb event
-      // TBD: Should the last activity timestamp here be "now" (after
-      // successful upload) or before the upload?
-      this.updateLastActivity(lastActivity);
+      // `timestamp` should reflect when the event happens. e.g. the timestamp
+      // of the event is passed as an argument in the case where a timeout
+      // occurs.
+      this.updateLastActivity(timestamp);
 
       captureEvent({
         timestamp,

--- a/src/index.ts
+++ b/src/index.ts
@@ -198,7 +198,7 @@ export class SentryReplay implements Integration {
     });
 
     // Otherwise, these will be captured after the first flush, which means the
-    // URL and timestamps could incorrect
+    // URL and timestamps could be incorrect
     this.initialState = {
       timestamp: new Date().getTime(),
       url: `${window.location.origin}${window.location.pathname}`,

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,3 +77,11 @@ export interface SentryReplayConfiguration extends SentryReplayPluginOptions {
    */
   recordingConfig?: RecordingConfig;
 }
+
+/**
+ * Some initial state captured before creating a root replay event
+ */
+export interface InitialState {
+  timestamp: number;
+  url: string;
+}

--- a/src/util/supportsSendBeacon.ts
+++ b/src/util/supportsSendBeacon.ts
@@ -1,0 +1,6 @@
+/**
+ * Determine if there is browser support for `navigator.sendBeacon`
+ */
+export function supportsSendBeacon() {
+  return 'navigator' in window && 'sendBeacon' in window.navigator;
+}


### PR DESCRIPTION
Ensure that we capture the correct initial state (e.g. timestamps + url) when sending the root replay event, as well as replay updates (timestamp only). For the root event, we defer creating + sending the event until after a certain amount of time + events elapses, but the session start point should be when we first start collecting replay events (recordings or otherwise).

For replay updates, the timestamp should be the time when we start flushing the event buffer, but the event should only be created after successfully uploading the replay.

Note backend will need to be able to support the arbitrary starting timestamp as normal event ingestion does not.
