### PR TITLE
fix: Sentry event timestamps need to be in seconds

### DIFF
--- a/src/api/captureReplay.ts
+++ b/src/api/captureReplay.ts
@@ -9,7 +9,7 @@ export function captureReplay(session: Session, initialState: InitialState) {
     {
       message: ROOT_REPLAY_NAME,
       tags: { segmentId: session.segmentId, url: initialState.url },
-      timestamp: initialState.timestamp,
+      timestamp: initialState.timestamp / 1000,
     },
     { event_id: session.id }
   );

--- a/src/api/captureReplayUpdate.ts
+++ b/src/api/captureReplayUpdate.ts
@@ -6,7 +6,7 @@ import type { Session } from '@/session/Session';
 
 export function captureReplayUpdate(session: Session, timestamp: number) {
   captureEvent({
-    timestamp,
+    timestamp: timestamp / 1000,
     message: `${REPLAY_EVENT_NAME}-${uuid4().substring(16)}`,
     tags: {
       replayId: session.id,

--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -258,7 +258,7 @@ describe('SentryReplay (capture only on error)', () => {
 
     expect(captureEventMock).toHaveBeenCalledWith(
       expect.objectContaining({
-        timestamp: BASE_TIMESTAMP + 5000, // the exception happened roughly 5 seconds after BASE_TIMESTAMP
+        timestamp: (BASE_TIMESTAMP + 5000) / 1000, // the exception happened roughly 5 seconds after BASE_TIMESTAMP
       })
     );
     expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));


### PR DESCRIPTION
Instead of milliseconds...

Closes #126
