### PR TITLE
feat: Collect Sentry error event ids when creating replay events

### DIFF
--- a/src/api/captureReplay.ts
+++ b/src/api/captureReplay.ts
@@ -7,14 +7,21 @@ import { InitialState } from '@/types';
 interface CaptureReplayParams {
   session: Session;
   initialState: InitialState;
+  errorIds: string[];
 }
 
-export function captureReplay({ session, initialState }: CaptureReplayParams) {
+export function captureReplay({
+  session,
+  initialState,
+  errorIds,
+}: CaptureReplayParams) {
   captureEvent(
     {
       message: ROOT_REPLAY_NAME,
       tags: { segmentId: session.segmentId, url: initialState.url },
       timestamp: initialState.timestamp / 1000,
+      // @ts-expect-error replay event type accepts this
+      errorIds,
     },
     { event_id: session.id }
   );

--- a/src/api/captureReplayUpdate.ts
+++ b/src/api/captureReplayUpdate.ts
@@ -10,14 +10,18 @@ interface CaptureReplayUpdateParams {
    * Timestamp of the event in milliseconds
    */
   timestamp: number;
+  errorIds: string[];
 }
 export function captureReplayUpdate({
   session,
   timestamp,
+  errorIds,
 }: CaptureReplayUpdateParams) {
   captureEvent({
     timestamp: timestamp / 1000,
     message: `${REPLAY_EVENT_NAME}-${uuid4().substring(16)}`,
+    // @ts-expect-error replay event type accepts this
+    errorIds,
     tags: {
       replayId: session.id,
       segmentId: session.segmentId++,

--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -249,18 +249,20 @@ describe('SentryReplay (capture only on error)', () => {
     await new Promise(process.nextTick);
     await new Promise(process.nextTick);
 
-    expect(captureReplayMock).toHaveBeenCalledWith(
+    expect(captureReplayMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         initialState: {
           timestamp: BASE_TIMESTAMP,
           url: 'http://localhost/',
         },
+        errorIds: [expect.any(String)],
       })
     );
 
-    expect(captureEventMock).toHaveBeenCalledWith(
+    expect(captureEventMock).toHaveBeenLastCalledWith(
       expect.objectContaining({
         timestamp: (BASE_TIMESTAMP + 5000) / 1000, // the exception happened roughly 5 seconds after BASE_TIMESTAMP
+        errorIds: [],
       })
     );
     expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));


### PR DESCRIPTION
Change the core SDK global event listener to collect the ids of error
events (currently all events besides transactions). These will be sent
in the replay event payload.
