### PR TITLE
feat: Do not send breadcrumbs with replay event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -405,6 +405,9 @@ export class SentryReplay implements Integration {
       event.message === ROOT_REPLAY_NAME ||
       event.message?.startsWith(REPLAY_EVENT_NAME)
     ) {
+      // Replays have separate set of breadcrumbs, do not include breadcrumbs
+      // from core SDK
+      delete event.breadcrumbs;
       return event;
     }
 


### PR DESCRIPTION
Since replays include its own crumbs, no need to send breadcrumbs from core SDK with replay events.

Closes #119
