### PR TITLE
feat: Use core SDK request data to augment `window.performance`

### DIFF
--- a/src/createPerformanceEntry.ts
+++ b/src/createPerformanceEntry.ts
@@ -96,16 +96,13 @@ function createResourceEntry(entry: PerformanceResourceTiming) {
     name,
     responseEnd,
     startTime,
+    decodedBodySize,
+    encodedBodySize,
     transferSize,
   } = entry;
 
   // Do not capture fetches to Sentry ingestion endpoint
   if (isIngestHost(name)) {
-    return null;
-  }
-
-  // Core SDK handles these
-  if (['fetch', 'xmlhttprequest'].includes(initiatorType)) {
     return null;
   }
 
@@ -115,7 +112,9 @@ function createResourceEntry(entry: PerformanceResourceTiming) {
     end: getAbsoluteTime(responseEnd),
     name,
     data: {
-      size: transferSize,
+      size: decodedBodySize,
+      encodedBodySize,
+      transferSize,
     },
   };
 }

--- a/src/eventBuffer.ts
+++ b/src/eventBuffer.ts
@@ -166,13 +166,12 @@ export class EventBufferCompressionWorker implements IEventBuffer {
   }
 
   sendEventToWorker = (event: RecordingEvent) => {
+    // TODO: error handling when `event` is not able to be serialized
     const promise = this.postMessage({
       id: this.id,
       method: 'addEvent',
       args: [event],
     });
-
-    logger.log('Message posted to worker');
 
     // XXX: See note in `get length()`
     this.eventBufferItemLength++;

--- a/src/util/getAdditionalRequestData.ts
+++ b/src/util/getAdditionalRequestData.ts
@@ -1,0 +1,42 @@
+import { ReplayPerformanceEntry } from '@/createPerformanceEntry';
+
+function getData(
+  entry: ReplayPerformanceEntry,
+  coreRequests: ReplayPerformanceEntry[]
+) {
+  if (
+    entry.type !== 'resource.fetch' &&
+    entry.type !== 'resource.xmlhttprequest'
+  ) {
+    return entry;
+  }
+
+  const found = coreRequests.filter(
+    (coreRequest) => coreRequest.name === entry.name
+  );
+
+  // Multiple requests with same URL found... give up
+  // TODO: Return the "closest" request 😬
+  if (found.length > 1) {
+    return entry;
+  }
+
+  if (found.length === 0) {
+    return entry;
+  }
+
+  return {
+    ...entry,
+    data: {
+      ...entry.data,
+      ...found[0].data,
+    },
+  };
+}
+
+export function getAdditionalRequestData(
+  entries: ReplayPerformanceEntry[],
+  coreRequests: ReplayPerformanceEntry[]
+): ReplayPerformanceEntry[] {
+  return entries.map((entry) => getData(entry, coreRequests));
+}


### PR DESCRIPTION
core SDK provides HTTP status code and method, while we need `window.performance` for transfer size.
