### PR TITLE
feat: Auto increment `segmentId` when it is read

### DIFF
--- a/src/api/captureReplay.ts
+++ b/src/api/captureReplay.ts
@@ -28,7 +28,7 @@ export function captureReplay({
       trace_ids: traceIds,
       urls,
       replay_id: session.id,
-      segment_id: session.segmentId, // TODO: Should this increment?
+      segment_id: session.segmentId,
     },
     { event_id: session.id }
   );

--- a/src/api/captureReplayUpdate.ts
+++ b/src/api/captureReplayUpdate.ts
@@ -28,6 +28,6 @@ export function captureReplayUpdate({
     trace_ids: traceIds,
     urls,
     replay_id: session.id,
-    segment_id: ++session.segmentId,
+    segment_id: session.segmentId,
   });
 }

--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -137,7 +137,10 @@ describe('SentryReplay (no sticky)', () => {
 
     // Session's last activity should be updated
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP + ELAPSED);
-    expect(replay.session.segmentId).toBe(1);
+
+    // after captureReplay - segmentId will be 1
+    // after captureReplayUpdate is called, it will be 2
+    expect(replay.session.segmentId).toBe(2);
 
     // events array should be empty
     expect(replay.eventBuffer.length).toBe(0);
@@ -156,7 +159,7 @@ describe('SentryReplay (no sticky)', () => {
 
     // No activity has occurred, session's last activity should remain the same
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP);
-    expect(replay.session.segmentId).toBe(1);
+    expect(replay.session.segmentId).toBe(2);
 
     // events array should be empty
     expect(replay.eventBuffer.length).toBe(0);
@@ -185,7 +188,7 @@ describe('SentryReplay (no sticky)', () => {
     expect(replay).not.toHaveSentReplay();
 
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP + 16000);
-    expect(replay.session.segmentId).toBe(1);
+    expect(replay.session.segmentId).toBe(2);
     // events array should be empty
     expect(replay.eventBuffer.length).toBe(0);
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -245,7 +245,7 @@ describe('SentryReplay', () => {
 
     // No activity has occurred, session's last activity should remain the same
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP);
-    expect(replay.session.segmentId).toBe(1);
+    expect(replay.session.segmentId).toBe(2);
 
     // events array should be empty
     expect(replay.eventBuffer.length).toBe(0);
@@ -275,7 +275,7 @@ describe('SentryReplay', () => {
     expect(replay).not.toHaveSentReplay();
 
     expect(replay.session.lastActivity).toBe(BASE_TIMESTAMP + 16000);
-    expect(replay.session.segmentId).toBe(1);
+    expect(replay.session.segmentId).toBe(2);
     // events array should be empty
     expect(replay.eventBuffer.length).toBe(0);
 
@@ -381,7 +381,7 @@ describe('SentryReplay', () => {
       ])
     );
 
-    expect(replay.session.segmentId).toBe(1);
+    expect(replay.session.segmentId).toBe(2);
 
     // breadcrumbs array should be empty
     expect(replay.breadcrumbs).toHaveLength(0);
@@ -438,7 +438,7 @@ describe('SentryReplay', () => {
 
     // No activity has occurred, session's last activity should remain the same
     expect(replay.session.lastActivity).toBeGreaterThanOrEqual(BASE_TIMESTAMP);
-    expect(replay.session.segmentId).toBe(1);
+    expect(replay.session.segmentId).toBe(2);
 
     // next tick should do nothing
 
@@ -469,7 +469,7 @@ describe('SentryReplay', () => {
     await new Promise(process.nextTick);
     expect(replay.sendReplayRequest).toHaveBeenCalled();
     expect(captureReplayMock).toHaveBeenCalled();
-    expect(replay.session.segmentId).toBe(1);
+    expect(replay.session.segmentId).toBe(2);
 
     (
       replay.sendReplayRequest as jest.MockedFunction<
@@ -483,7 +483,9 @@ describe('SentryReplay', () => {
     await new Promise(process.nextTick);
     expect(replay.sendReplayRequest).toHaveBeenCalled();
     expect(captureReplayMock).not.toHaveBeenCalled();
-    expect(replay.session.segmentId).toBe(2);
+    // 2 additional segments from captureReplayUpdate and accessing segmentId in
+    // the assertion above
+    expect(replay.session.segmentId).toBe(4);
   });
 
   it('does not create root event when there are no events to send', async () => {

--- a/src/session/Session.test.ts
+++ b/src/session/Session.test.ts
@@ -30,10 +30,7 @@ it('non-sticky Session does not save to local storage', function () {
   expect(saveSession).not.toHaveBeenCalled();
   expect(newSession.id).toBe('test_session_id');
   expect(newSession.segmentId).toBe(0);
-
-  newSession.segmentId++;
   expect(saveSession).not.toHaveBeenCalled();
-  expect(newSession.segmentId).toBe(1);
 });
 
 it('sticky Session saves to local storage', function () {
@@ -43,14 +40,10 @@ it('sticky Session saves to local storage', function () {
   expect(newSession.id).toBe('test_session_id');
   expect(newSession.segmentId).toBe(0);
 
-  (saveSession as jest.Mock).mockClear();
-
-  newSession.segmentId++;
   expect(saveSession).toHaveBeenCalledTimes(1);
   expect(saveSession).toHaveBeenCalledWith(
     expect.objectContaining({
       segmentId: 1,
     })
   );
-  expect(newSession.segmentId).toBe(1);
 });

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -101,15 +101,32 @@ export class Session {
     }
   }
 
+  /**
+   * Returns the current `segmentId` and then increments (and saves to session if
+   * sticky)
+   */
   get segmentId() {
-    return this._segmentId;
-  }
+    const value = this._segmentId;
 
-  set segmentId(id: number) {
-    this._segmentId = id;
+    // Auto increment segmentId everytime it is accessed to avoid
+    // the possibility of duplicate segmentIds.
+    this._segmentId++;
+
     if (this.options.stickySession) {
       saveSession(this);
     }
+
+    return value;
+  }
+
+  /**
+   * This is probably not what you want to do as the getter will auto
+   * increment.
+   */
+  set segmentId(_id: number) {
+    throw new Error(
+      'Setting `segmentId` is not supported, the getter will auto increment `segmentId`.'
+    );
   }
 
   get previousSessionId() {


### PR DESCRIPTION
Changes the behavior of `Session.segmentId` - using the setter will throw an exception. Instead the only interface will be to read from it, which will also increment the id. This should greatly reduce the chance of having duplicate `segmentId`s at the risk of having missing/non-sequential ids.
