### PR TITLE
fix: Fix resetting initial state when loading new session

### DIFF
--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -260,7 +260,7 @@ describe('SentryReplay (capture only on error)', () => {
         },
         errorIds: [expect.any(String)],
         traceIds: [],
-        urls: [],
+        urls: ['http://localhost/'],
       })
     );
 
@@ -273,7 +273,7 @@ describe('SentryReplay (capture only on error)', () => {
         type: 'replay_event',
         error_ids: [expect.any(String)],
         trace_ids: [],
-        urls: [],
+        urls: ['http://localhost/'],
         replay_id: expect.any(String),
         segment_id: 0,
       }),

--- a/src/index-sampling.test.ts
+++ b/src/index-sampling.test.ts
@@ -20,7 +20,10 @@ describe('SentryReplay (sampling)', () => {
 
     expect(replay.session.sampled).toBe(false);
     // @ts-expect-error private
-    expect(replay.initialState).toEqual(undefined);
+    expect(replay.initialState).toEqual({
+      timestamp: expect.any(Number),
+      url: 'http://localhost/',
+    });
     expect(mockRecord).not.toHaveBeenCalled();
     expect(replay.addListeners).not.toHaveBeenCalled();
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -19,6 +19,8 @@ async function advanceTimers(time: number) {
 
 describe('SentryReplay', () => {
   let replay: SentryReplay;
+  const prevLocation = window.location;
+
   type MockSendReplayRequest = jest.MockedFunction<
     typeof replay.sendReplayRequest
   >;
@@ -69,6 +71,11 @@ describe('SentryReplay', () => {
     replay.clearSession();
     replay.loadSession({ expiry: SESSION_IDLE_DURATION });
     mockRecord.takeFullSnapshot.mockClear();
+    delete window.location;
+    Object.defineProperty(window, 'location', {
+      value: prevLocation,
+      writable: true,
+    });
   });
 
   afterAll(() => {
@@ -290,7 +297,6 @@ describe('SentryReplay', () => {
   });
 
   it('creates a new session if user has been idle for more than 15 minutes and comes back to move their mouse', async () => {
-    const oldLocation = window.location;
     const initialSession = replay.session;
 
     expect(initialSession.id).toBeDefined();
@@ -300,8 +306,6 @@ describe('SentryReplay', () => {
       timestamp: BASE_TIMESTAMP,
     });
 
-    // jest.spyOn(window, 'location')
-    // global.window = Object.create(window);
     const url = 'http://dummy/';
     Object.defineProperty(window, 'location', {
       value: new URL(url),
@@ -371,11 +375,6 @@ describe('SentryReplay', () => {
     expect(replay.initialState).toEqual({
       url: 'http://dummy/',
       timestamp: newTimestamp,
-    });
-
-    delete window.location;
-    Object.defineProperty(window, 'location', {
-      value: oldLocation,
     });
   });
 


### PR DESCRIPTION
This resets initial state when we load a new session (e.g. due to inactivity). I believe this is what is causing our durations to be all over the place. If a user starts a new session, it should reset the initial state, otherwise the replay start time will always be the whenever the tab was first opened, instead of when a new session is created.
