### PR TITLE
feat: capture exception to Sentry when uploading replay fails

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -3,6 +3,7 @@ import {
   captureException,
   getCurrentHub,
   getEnvelopeEndpointWithUrlEncodedAuth,
+  setContext,
 } from '@sentry/core';
 import { Breadcrumb, Event, Integration } from '@sentry/types';
 import { addInstrumentationHandler } from '@sentry/utils';
@@ -945,6 +946,9 @@ export class SentryReplay implements Integration {
       console.error(ex);
       // Capture error for every failed replay
       // TODO: Remove this before GA as this will create an error on customer's project
+      setContext('Replays', {
+        retryCount: this.retryCount,
+      });
       captureException(new Error(UNABLE_TO_SEND_REPLAY));
 
       // If an error happened here, it's likely that uploading the attachment

--- a/src/index.ts
+++ b/src/index.ts
@@ -910,10 +910,17 @@ export class SentryReplay implements Integration {
 
     // Otherwise use `fetch`, which *WILL* get cancelled on page reloads/unloads
     logger.log(`uploading attachment via fetch()`);
-    await fetch(endpoint, {
+    const response = await fetch(endpoint, {
       method: 'POST',
       body: serializeEnvelope(envelope),
     });
+    if (response.status !== 200) {
+      setContext('Send Replay Response', {
+        status: response.status,
+        body: await response.text(),
+      });
+      throw new Error(UNABLE_TO_SEND_REPLAY);
+    }
   }
 
   resetRetries() {


### PR DESCRIPTION
This is temporary to debug if we are facing client side failures when uploading replays.
