### PR TITLE
feat: Remove sendBeacon() usage 

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,6 @@ import { createPayload } from './util/createPayload';
 import { isExpired } from './util/isExpired';
 import { isSessionExpired } from './util/isSessionExpired';
 import { logger } from './util/logger';
-import { supportsSendBeacon } from './util/supportsSendBeacon';
 import {
   createMemoryEntry,
   createPerformanceEntries,
@@ -869,7 +868,7 @@ export class SentryReplay implements Integration {
   }
 
   /**
-   * Send replay attachment using either `sendBeacon()` or `fetch()`
+   * Send replay attachment using or `fetch()`
    */
   async sendReplayRequest({ endpoint, events }: ReplayRequest) {
     const payloadWithSequence = createPayload({
@@ -896,13 +895,6 @@ export class SentryReplay implements Integration {
         ],
       ]
     );
-
-    // If sendBeacon is supported and payload is smol enough...
-    if (supportsSendBeacon() && events.length <= 65536) {
-      logger.log(`uploading attachment via sendBeacon()`);
-      window.navigator.sendBeacon(endpoint, serializeEnvelope(envelope));
-      return;
-    }
 
     // Otherwise use `fetch`, which *WILL* get cancelled on page reloads/unloads
     logger.log(`uploading attachment via fetch()`);

--- a/src/index.ts
+++ b/src/index.ts
@@ -868,7 +868,7 @@ export class SentryReplay implements Integration {
   }
 
   /**
-   * Send replay attachment using or `fetch()`
+   * Send replay attachment using `fetch()`
    */
   async sendReplayRequest({ endpoint, events }: ReplayRequest) {
     const payloadWithSequence = createPayload({

--- a/src/util/supportsSendBeacon.ts
+++ b/src/util/supportsSendBeacon.ts
@@ -1,6 +1,0 @@
-/**
- * Determine if there is browser support for `navigator.sendBeacon`
- */
-export function supportsSendBeacon() {
-  return 'navigator' in window && 'sendBeacon' in window.navigator;
-}


### PR DESCRIPTION
Theres not too much of a reason to use this, lets keep things simple and just use fetch which is well supported. I believe I added this to capture the window unload event, but even that does not work consistently anyway.

I was also seeing these warnings https://chromestatus.com/feature/5629709824032768 -- which is harmless in our case as it seems to block the *response* which we don't care about.
