### PR TITLE
ref(tests): Refactor `addEvent` call

### DIFF
--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -142,7 +142,7 @@ describe('SentryReplay (capture only on error)', () => {
     jest.advanceTimersByTime(ELAPSED);
 
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
-    replay.eventBuffer.addEvent(TEST_EVENT);
+    replay.addEvent(TEST_EVENT);
 
     document.dispatchEvent(new Event('visibilitychange'));
     await new Promise(process.nextTick);

--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -125,7 +125,7 @@ describe('SentryReplay (no sticky)', () => {
     jest.advanceTimersByTime(ELAPSED);
 
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
-    replay.eventBuffer.addEvent(TEST_EVENT);
+    replay.addEvent(TEST_EVENT);
 
     document.dispatchEvent(new Event('visibilitychange'));
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -198,7 +198,7 @@ describe('SentryReplay', () => {
       },
     };
 
-    replay.eventBuffer.addEvent(TEST_EVENT);
+    replay.addEvent(TEST_EVENT);
     window.dispatchEvent(new Event('blur'));
     await new Promise(process.nextTick);
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
@@ -225,7 +225,7 @@ describe('SentryReplay', () => {
 
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
 
-    replay.eventBuffer.addEvent(TEST_EVENT);
+    replay.addEvent(TEST_EVENT);
     document.dispatchEvent(new Event('visibilitychange'));
     await new Promise(process.nextTick);
 
@@ -488,7 +488,7 @@ describe('SentryReplay', () => {
 
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
 
-    replay.eventBuffer.addEvent(TEST_EVENT);
+    replay.addEvent(TEST_EVENT);
     window.dispatchEvent(new Event('blur'));
     await new Promise(process.nextTick);
     expect(replay.sendReplayRequest).toHaveBeenCalled();
@@ -502,7 +502,7 @@ describe('SentryReplay', () => {
     ).mockClear();
     captureReplayMock.mockClear();
 
-    replay.eventBuffer.addEvent(TEST_EVENT);
+    replay.addEvent(TEST_EVENT);
     window.dispatchEvent(new Event('blur'));
     await new Promise(process.nextTick);
     expect(replay.sendReplayRequest).toHaveBeenCalled();
@@ -533,7 +533,7 @@ describe('SentryReplay', () => {
       type: 2,
     };
 
-    replay.eventBuffer.addEvent(TEST_EVENT);
+    replay.addEvent(TEST_EVENT);
     window.dispatchEvent(new Event('blur'));
     await new Promise(process.nextTick);
     expect(captureReplayMock).toHaveBeenCalledWith(


### PR DESCRIPTION
Tests should not call `addEvent()` directly on event buffer, should be on plugin class.
