### PR TITLE
feat: Inspect events for earliest timestamp 

### DIFF
--- a/src/api/captureReplayUpdate.ts
+++ b/src/api/captureReplayUpdate.ts
@@ -23,7 +23,7 @@ export function captureReplayUpdate({
   captureEvent({
     // @ts-expect-error replay_event is a new event type
     type: REPLAY_EVENT_NAME,
-    replay_start_timestamp: timestamp / 1000,
+    timestamp: timestamp / 1000,
     error_ids: errorIds,
     trace_ids: traceIds,
     urls,

--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -286,10 +286,7 @@ describe('SentryReplay (capture only on error)', () => {
         // the exception happened roughly 5 seconds after BASE_TIMESTAMP (i.e. 5
         // seconds after root replay event). extra time is likely due to async
         // of `addMemoryEntry()`
-        replay_start_timestamp: expect.closeTo(
-          (BASE_TIMESTAMP + 5000) / 1000,
-          1
-        ),
+        timestamp: expect.closeTo((BASE_TIMESTAMP + 5000) / 1000, 1),
         error_ids: [],
         trace_ids: [],
         urls: [],

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,4 +111,9 @@ export interface ReplayEventContext {
    * Ordered list of URLs that have been visited during a replay segment
    */
   urls: string[];
+
+  /**
+   * The timestamp of the earliest event that has been added to event buffer. This can happen due to the Performance Observer which buffers events.
+   */
+  earliestEvent: number | null;
 }


### PR DESCRIPTION
We need to inspect events before they hit the event buffer (bc of compression) and keep track of the timestamp of the earliest event. This can happen because entries in the Performance Observer are buffered so they can occur before the integration is initialized.

This also fixes replay update events where we pass the replay start time, but we need to defined the timestamp, as that is used to calculate the finishedAt timestamp.