### PR TITLE
feat: Do not flush for network requests

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -560,6 +560,10 @@ export class SentryReplay implements Integration {
 
       this.addUpdate(() => {
         this.createPerformanceSpans([result as ReplayPerformanceEntry]);
+        // Returning true will cause `addUpdate` to not flush
+        // We do not want network requests to cause a flush. This will prevent
+        // recurring/polling requests from keeping the replay session alive.
+        return ['xhr', 'fetch'].includes(type);
       });
     };
 


### PR DESCRIPTION
This makes a change to not flush when receiving network request events. The reason for this is to prevent recurring requests from keeping the replay session alive. Only capture if a user action (e.g. click, navigation) or recording event happens.
