### PR TITLE
feat: Do not create blur/focus breadcrumbs when expired

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -621,14 +621,8 @@ export class SentryReplay implements Integration {
 
     const isExpired = isSessionExpired(this.session, VISIBILITY_CHANGE_TIMEOUT);
 
-    if (breadcrumb) {
-      this.createCustomBreadcrumb({
-        ...breadcrumb,
-        // if somehow the page went hidden while session is expired, attach to previous session
-        timestamp: isExpired
-          ? this.session.lastActivity / 1000
-          : breadcrumb.timestamp,
-      });
+    if (breadcrumb && !isExpired) {
+      this.createCustomBreadcrumb(breadcrumb);
     }
 
     // Send replay when the page/tab becomes hidden. There is no reason to send
@@ -647,15 +641,6 @@ export class SentryReplay implements Integration {
 
     const isExpired = isSessionExpired(this.session, VISIBILITY_CHANGE_TIMEOUT);
 
-    if (breadcrumb) {
-      this.createCustomBreadcrumb({
-        ...breadcrumb,
-        timestamp: isExpired
-          ? new Date().getTime() / 1000
-          : breadcrumb.timestamp,
-      });
-    }
-
     if (isExpired) {
       // If the user has come back to the page within VISIBILITY_CHANGE_TIMEOUT
       // ms, we will re-use the existing session, otherwise create a new
@@ -664,6 +649,10 @@ export class SentryReplay implements Integration {
       this.loadSession({ expiry: VISIBILITY_CHANGE_TIMEOUT });
       this.triggerFullSnapshot();
       return;
+    }
+
+    if (breadcrumb) {
+      this.createCustomBreadcrumb(breadcrumb);
     }
 
     // Otherwise if session is not expired...


### PR DESCRIPTION
This was an attempt of trying to not losing blur/focus crumbs but dont think it was working as expected. Disregard these breadcrumbs if session is expired.
