### PR TITLE
feat: Do not alter time.

### DIFF
--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -154,8 +154,9 @@ describe('SentryReplay (no sticky)', () => {
 
     expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));
 
-    // No activity has occurred, session's last activity should remain the same
-    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
+    // Right before sending a replay, we add memory usage and perf entries,
+    // which we are considering as an "activity" here.
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP + ELAPSED);
     expect(replay.session?.segmentId).toBe(1);
 
     // events array should be empty

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -252,8 +252,9 @@ describe('SentryReplay', () => {
     expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
     expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));
 
-    // No activity has occurred, session's last activity should remain the same
-    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
+    // Right before sending a replay, we add memory usage and perf entries,
+    // which we are considering as an "activity" here.
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP + ELAPSED);
     expect(replay.session?.segmentId).toBe(1);
 
     // events array should be empty

--- a/src/index.ts
+++ b/src/index.ts
@@ -122,7 +122,6 @@ export class SentryReplay implements Integration {
     traceIds: new Set(),
     urls: [],
     earliestEvent: null,
-    latestEvent: null,
   };
 
   session: Session | undefined;


### PR DESCRIPTION
Stop messing with time so much.

With the introduction of `replay_start_timestamp` and keeping track of the earliest timestamp, we can simplify `flushUpdate`, so that we are not attempting to preserve timestamps. At the time of flushing, we would capture memory metrics at that current timestamp, which was after the "preserved" timestamp. This caused our durations to be incorrect (which is calculated using the preserved timestamp as the end timestamp).

`captureReplayUpdate`s timestamp should now always be after all of the breadcrumbs that have been collected thus far. 


Before:
![image](https://user-images.githubusercontent.com/79684/187984122-1403f503-a8ba-4048-83e9-64a170d43fe4.png)

After:
![image](https://user-images.githubusercontent.com/79684/187984206-ae0d402a-e353-472b-b2f8-5fbc19f15685.png)

