### PR TITLE
feat: Make `stickySession` default to `true`

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Sentry.init({
   dsn: '__DSN__',
   integrations: [
     new SentryReplay({
-      stickySession: true, // Default is false
+      stickySession: false, // Default is true
       recordingConfig: {
         maskAllInputs: false, // Default is true
       },
@@ -54,7 +54,7 @@ Sentry.init({
 | `flushMinDelay` | `number` | `5000` | The minimum time to wait (in ms) before sending the recording payload. The payload is sent if `flushMinDelay` ms have elapsed between two events. |
 | `flushMaxDelay` | `number` | `15000` | The maximum time to wait (in ms) when sending the recording payload. The payload is sent if events occur at an interval less than `flushMinDelay` and `flushMaxDelay` ms have elapsed since the last time a payload was sent. |
 | `initialFlushDelay` | `number` | `5000` | The amount of time to wait (in ms) before sending the initial recording payload. This helps drop recordings where users visit and close the page quickly. |
-| `stickySession` | `boolean` | `false` | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well. |
+| `stickySession` | `boolean` | `true` | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well. |
 | `useCompression` | `boolean` | `true` | Uses `WebWorkers` (if available) to compress the recording payload before uploading to Sentry. |
 | `captureOnlyOnError` | `boolean` | `false` | Only capture the recording when an error happens. |
 | `replaysSamplingRate` | `number` | `1.0` | The rate at which to sample replays. (1.0 will collect all replays, 0 will collect no replays). |

--- a/src/index.ts
+++ b/src/index.ts
@@ -130,7 +130,7 @@ export class SentryReplay implements Integration {
     flushMinDelay = 5000,
     flushMaxDelay = 15000,
     initialFlushDelay = 5000,
-    stickySession = false, // TBD: Making this opt-in for now
+    stickySession = true,
     useCompression = true,
     captureOnlyOnError = false,
     replaysSamplingRate = 1.0,


### PR DESCRIPTION
The plugin is less useful when this is `false`, especially in the case of non-SPAs
