### PR TITLE
feat: Add feature to stop recording/plugin

### DIFF
--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -63,7 +63,7 @@ describe('SentryReplay (capture only on error)', () => {
     await new Promise(process.nextTick);
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     replay.clearSession();
-    replay.eventBuffer.destroy();
+    replay.eventBuffer?.destroy();
     replay.loadSession({ expiry: SESSION_IDLE_DURATION });
   });
 

--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -140,7 +140,7 @@ describe('SentryReplay (no sticky)', () => {
     expect(replay.session?.segmentId).toBe(1);
 
     // events array should be empty
-    expect(replay.eventBuffer.length).toBe(0);
+    expect(replay.eventBuffer?.length).toBe(0);
   });
 
   it('uploads a replay event if 5 seconds have elapsed since the last replay event occurred', async () => {
@@ -159,7 +159,7 @@ describe('SentryReplay (no sticky)', () => {
     expect(replay.session?.segmentId).toBe(1);
 
     // events array should be empty
-    expect(replay.eventBuffer.length).toBe(0);
+    expect(replay.eventBuffer?.length).toBe(0);
   });
 
   it('uploads a replay event if 15 seconds have elapsed since the last replay upload', async () => {
@@ -187,7 +187,7 @@ describe('SentryReplay (no sticky)', () => {
     expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP + 16000);
     expect(replay.session?.segmentId).toBe(1);
     // events array should be empty
-    expect(replay.eventBuffer.length).toBe(0);
+    expect(replay.eventBuffer?.length).toBe(0);
 
     // Let's make sure it continues to work
     mockSendReplayRequest.mockClear();

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -60,7 +60,7 @@ describe('SentryReplay', () => {
   beforeEach(() => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     mockSendReplayRequest.mockClear();
-    replay.eventBuffer.destroy();
+    replay.eventBuffer?.destroy();
   });
 
   afterEach(async () => {
@@ -211,7 +211,7 @@ describe('SentryReplay', () => {
     // Session's last activity should be updated
     expect(replay.session?.lastActivity).toBeGreaterThan(BASE_TIMESTAMP);
     // events array should be empty
-    expect(replay.eventBuffer.length).toBe(0);
+    expect(replay.eventBuffer?.length).toBe(0);
   });
 
   it('uploads a replay event when document becomes hidden', async () => {
@@ -238,7 +238,7 @@ describe('SentryReplay', () => {
     // Session's last activity should be updated
     expect(replay.session?.lastActivity).toBeGreaterThan(BASE_TIMESTAMP);
     // events array should be empty
-    expect(replay.eventBuffer.length).toBe(0);
+    expect(replay.eventBuffer?.length).toBe(0);
   });
 
   it('uploads a replay event if 5 seconds have elapsed since the last replay event occurred', async () => {
@@ -257,7 +257,7 @@ describe('SentryReplay', () => {
     expect(replay.session?.segmentId).toBe(1);
 
     // events array should be empty
-    expect(replay.eventBuffer.length).toBe(0);
+    expect(replay.eventBuffer?.length).toBe(0);
   });
 
   it('uploads a replay event if 15 seconds have elapsed since the last replay upload', async () => {
@@ -286,7 +286,7 @@ describe('SentryReplay', () => {
     expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP + 16000);
     expect(replay.session?.segmentId).toBe(1);
     // events array should be empty
-    expect(replay.eventBuffer.length).toBe(0);
+    expect(replay.eventBuffer?.length).toBe(0);
 
     // Let's make sure it continues to work
     mockSendReplayRequest.mockClear();

--- a/src/index.ts
+++ b/src/index.ts
@@ -702,6 +702,7 @@ export class SentryReplay implements Integration {
    */
   addEvent(event: RecordingEvent, isCheckout?: boolean) {
     if (!this.eventBuffer) {
+      // This implies that `isEnabled` is false
       return;
     }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,9 +300,9 @@ export class SentryReplay implements Integration {
    */
   destroy() {
     logger.log('Destroying instance');
+    this.isEnabled = false;
     this.removeListeners();
     this.stopRecording?.();
-    this.isEnabled = false;
     this.eventBuffer?.destroy();
     this.eventBuffer = null;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export class SentryReplay implements Integration {
    */
   public name: string = SentryReplay.id;
 
-  public eventBuffer: IEventBuffer;
+  public eventBuffer: IEventBuffer | null;
 
   /**
    * Buffer of breadcrumbs to be uploaded
@@ -111,6 +111,22 @@ export class SentryReplay implements Integration {
    * immediately before sending recording)
    */
   private needsCaptureReplay = false;
+
+  /**
+   * Is the integration currently active?
+   */
+  private isEnabled = false;
+
+  /**
+   * Have we attached listeners to the core SDK?
+   * Note we have to track this as there is no way to remove instrumentation handlers.
+   */
+  private hasInitializedCoreListeners = false;
+
+  /**
+   * Function to stop recording
+   */
+  private stopRecording: ReturnType<typeof record> | null = null;
 
   /**
    * Captured state when integration is first initialized
@@ -209,10 +225,12 @@ export class SentryReplay implements Integration {
     // replay ID so that we can reference them later in the UI
     addGlobalEventProcessor(this.handleGlobalEvent);
 
-    record({
+    this.stopRecording = record({
       ...this.recordingOptions,
       emit: this.handleRecordingEmit,
     });
+
+    this.isEnabled = true;
   }
 
   /**
@@ -283,6 +301,10 @@ export class SentryReplay implements Integration {
   destroy() {
     logger.log('Destroying instance');
     this.removeListeners();
+    this.stopRecording?.();
+    this.isEnabled = false;
+    this.eventBuffer?.destroy();
+    this.eventBuffer = null;
   }
 
   clearSession() {
@@ -342,16 +364,24 @@ export class SentryReplay implements Integration {
     window.addEventListener('blur', this.handleWindowBlur);
     window.addEventListener('focus', this.handleWindowFocus);
 
-    // Listeners from core SDK //
-    const scope = getCurrentHub().getScope();
-    scope?.addScopeListener(this.handleCoreBreadcrumbListener('scope'));
-    addInstrumentationHandler('dom', this.handleCoreBreadcrumbListener('dom'));
-    addInstrumentationHandler('fetch', this.handleCoreSpanListener('fetch'));
-    addInstrumentationHandler('xhr', this.handleCoreSpanListener('xhr'));
-    addInstrumentationHandler(
-      'history',
-      this.handleCoreSpanListener('history')
-    );
+    // There is no way to remove these listeners, so ensure they are only added once
+    if (!this.hasInitializedCoreListeners) {
+      // Listeners from core SDK //
+      const scope = getCurrentHub().getScope();
+      scope?.addScopeListener(this.handleCoreBreadcrumbListener('scope'));
+      addInstrumentationHandler(
+        'dom',
+        this.handleCoreBreadcrumbListener('dom')
+      );
+      addInstrumentationHandler('fetch', this.handleCoreSpanListener('fetch'));
+      addInstrumentationHandler('xhr', this.handleCoreSpanListener('xhr'));
+      addInstrumentationHandler(
+        'history',
+        this.handleCoreSpanListener('history')
+      );
+
+      this.hasInitializedCoreListeners = true;
+    }
 
     // PerformanceObserver //
     if (!('PerformanceObserver' in window)) {
@@ -533,6 +563,10 @@ export class SentryReplay implements Integration {
    */
   handleCoreSpanListener =
     (type: InstrumentationTypeSpan) => (handlerData: any) => {
+      if (!this.isEnabled) {
+        return;
+      }
+
       const handler = getSpanHandler(type);
       const result = handler(handlerData);
 
@@ -561,6 +595,10 @@ export class SentryReplay implements Integration {
    */
   handleCoreBreadcrumbListener =
     (type: InstrumentationTypeBreadcrumb) => (handlerData: any) => {
+      if (!this.isEnabled) {
+        return;
+      }
+
       const handler = getBreadcrumbHandler(type);
       const result = handler(handlerData);
 
@@ -663,6 +701,10 @@ export class SentryReplay implements Integration {
    * Add an event to the event buffer
    */
   addEvent(event: RecordingEvent, isCheckout?: boolean) {
+    if (!this.eventBuffer) {
+      return;
+    }
+
     const timestampInMs = event.timestamp * 1000;
     if (
       !this.context.earliestEvent ||
@@ -833,6 +875,12 @@ export class SentryReplay implements Integration {
    * due to the buffered performance observer events.
    */
   async flushUpdate(lastActivity?: number) {
+    if (!this.isEnabled) {
+      // This is just a precaution, there should be no listeners that would
+      // cause a flush.
+      return;
+    }
+
     if (!this.checkAndHandleExpiredSession()) {
       logger.error(
         new Error('Attempting to finish replay event after session expired.')
@@ -850,7 +898,7 @@ export class SentryReplay implements Integration {
 
     await this.addPerformanceEntries();
 
-    if (!this.eventBuffer.length) {
+    if (!this.eventBuffer?.length) {
       return;
     }
 

--- a/src/stop.test.ts
+++ b/src/stop.test.ts
@@ -1,0 +1,117 @@
+// mock functions need to be imported first
+import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
+
+import { SentryReplay } from '@';
+import { SESSION_IDLE_DURATION } from '@/session/constants';
+
+jest.useFakeTimers({ advanceTimers: true });
+
+describe('SentryReplay - stop', () => {
+  let replay: SentryReplay;
+  const prevLocation = window.location;
+
+  type MockSendReplayRequest = jest.MockedFunction<
+    typeof replay.sendReplayRequest
+  >;
+  let mockSendReplayRequest: MockSendReplayRequest;
+  const { record: mockRecord } = mockRrweb();
+
+  beforeAll(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    ({ replay } = mockSdk());
+    jest.spyOn(replay, 'sendReplayRequest');
+    mockSendReplayRequest = replay.sendReplayRequest as MockSendReplayRequest;
+    mockSendReplayRequest.mockImplementation(
+      jest.fn(async () => {
+        return;
+      })
+    );
+    jest.runAllTimers();
+  });
+
+  beforeEach(() => {
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    mockSendReplayRequest.mockClear();
+    replay.eventBuffer?.destroy();
+  });
+
+  afterEach(async () => {
+    jest.runAllTimers();
+    await new Promise(process.nextTick);
+    jest.setSystemTime(new Date(BASE_TIMESTAMP));
+    sessionStorage.clear();
+    replay.clearSession();
+    replay.loadSession({ expiry: SESSION_IDLE_DURATION });
+    mockRecord.takeFullSnapshot.mockClear();
+    // @ts-expect-error: The operand of a 'delete' operator must be optional.ts(2790)
+    delete window.location;
+    Object.defineProperty(window, 'location', {
+      value: prevLocation,
+      writable: true,
+    });
+  });
+
+  afterAll(() => {
+    replay && replay.destroy();
+  });
+
+  it('does not upload replay if it was stopped and can resume replays afterwards', async () => {
+    Object.defineProperty(document, 'visibilityState', {
+      configurable: true,
+      get: function () {
+        return 'hidden';
+      },
+    });
+    const ELAPSED = 5000;
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+
+    // stop replays
+    replay.destroy();
+
+    // Pretend 5 seconds have passed
+    jest.advanceTimersByTime(ELAPSED);
+
+    replay.addEvent(TEST_EVENT);
+    window.dispatchEvent(new Event('blur'));
+    await new Promise(process.nextTick);
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay.sendReplayRequest).not.toHaveBeenCalled();
+    expect(replay).not.toHaveSentReplay();
+    // Session's last activity should be updated
+    expect(replay.session?.lastActivity).toEqual(BASE_TIMESTAMP);
+    // eventBuffer is destroyed
+    expect(replay.eventBuffer).toBe(null);
+
+    // re-enable replay
+    replay.setup();
+
+    // Not sure where the .02 comes from tbh
+    const timestamp =
+      +new Date(BASE_TIMESTAMP + ELAPSED + ELAPSED) / 1000 + 0.02;
+    const hiddenBreadcrumb = {
+      type: 5,
+      timestamp,
+      data: {
+        tag: 'breadcrumb',
+        payload: {
+          timestamp,
+          type: 'default',
+          category: 'ui.blur',
+        },
+      },
+    };
+
+    jest.advanceTimersByTime(ELAPSED);
+    replay.addEvent(TEST_EVENT);
+    window.dispatchEvent(new Event('blur'));
+    await new Promise(process.nextTick);
+    expect(replay.sendReplayRequest).toHaveBeenCalled();
+    expect(replay).toHaveSentReplay(
+      JSON.stringify([TEST_EVENT, hiddenBreadcrumb])
+    );
+    // Session's last activity should be updated
+    expect(replay.session?.lastActivity).toBeGreaterThan(
+      BASE_TIMESTAMP + ELAPSED + ELAPSED
+    );
+  });
+});


### PR DESCRIPTION
Stop recording replays when `destroy()` is called. Also destroy Event Buffer.
