### PR TITLE
feat: Add `deleteSession()`

### DIFF
--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -6,6 +6,7 @@ import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 import { SentryReplay } from '@';
 import * as CaptureReplay from '@/api/captureReplay';
 import {
+  REPLAY_SESSION_KEY,
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
 } from '@/session/constants';
@@ -104,6 +105,12 @@ describe('SentryReplay', () => {
     expect(replay.session?.id).toBeDefined();
     expect(replay.session?.segmentId).toBeDefined();
     expect(captureReplayMock).not.toHaveBeenCalled();
+  });
+
+  it('clears session', () => {
+    replay.clearSession();
+    expect(window.sessionStorage.getItem(REPLAY_SESSION_KEY)).toBe(null);
+    expect(replay.session).toBe(undefined);
   });
 
   it('creates a new session and triggers a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,7 @@ import {
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
 } from './session/constants';
+import { deleteSession } from './session/deleteSession';
 import { getSession } from './session/getSession';
 import { Session } from './session/Session';
 import createBreadcrumb from './util/createBreadcrumb';
@@ -286,6 +287,7 @@ export class SentryReplay implements Integration {
   }
 
   clearSession() {
+    deleteSession();
     this.session = undefined;
   }
 

--- a/src/session/deleteSession.test.ts
+++ b/src/session/deleteSession.test.ts
@@ -1,0 +1,19 @@
+import { REPLAY_SESSION_KEY } from './constants';
+import { deleteSession } from './deleteSession';
+
+const storageEngine = window.sessionStorage;
+
+it('deletes a session', function () {
+  storageEngine.setItem(
+    REPLAY_SESSION_KEY,
+    '{"id":"fd09adfc4117477abc8de643e5a5798a","started":1648827162630,"lastActivity":1648827162658}'
+  );
+
+  deleteSession();
+
+  expect(storageEngine.getItem(REPLAY_SESSION_KEY)).toBe(null);
+});
+
+it('deletes an empty session', function () {
+  expect(() => deleteSession()).not.toThrow();
+});

--- a/src/session/deleteSession.ts
+++ b/src/session/deleteSession.ts
@@ -10,5 +10,9 @@ export function deleteSession(): void {
     return;
   }
 
-  window.sessionStorage.removeItem(REPLAY_SESSION_KEY);
+  try {
+    window.sessionStorage.removeItem(REPLAY_SESSION_KEY);
+  } catch {
+    // Ignore potential SecurityError exceptions
+  }
 }

--- a/src/session/deleteSession.ts
+++ b/src/session/deleteSession.ts
@@ -1,7 +1,7 @@
 import { REPLAY_SESSION_KEY } from './constants';
 
 /**
- * Fetches a session from storage
+ * Deletes a session from storage
  */
 export function deleteSession(): void {
   const hasSessionStorage = 'sessionStorage' in window;

--- a/src/session/deleteSession.ts
+++ b/src/session/deleteSession.ts
@@ -1,0 +1,14 @@
+import { REPLAY_SESSION_KEY } from './constants';
+
+/**
+ * Fetches a session from storage
+ */
+export function deleteSession(): void {
+  const hasSessionStorage = 'sessionStorage' in window;
+
+  if (!hasSessionStorage) {
+    return;
+  }
+
+  window.sessionStorage.removeItem(REPLAY_SESSION_KEY);
+}


### PR DESCRIPTION
Clears replay session from `sessionStorage`. Called when calling `clearSession()` from the plugin.
