### PR TITLE
feat: Reduce calls to `sessionStorage` when checking session life

### DIFF
--- a/src/session/getSession.ts
+++ b/src/session/getSession.ts
@@ -36,7 +36,8 @@ export function getSession({
   stickySession,
   samplingRate,
 }: GetSessionParams) {
-  const session = stickySession ? fetchSession() : currentSession;
+  // If session exists and is passed, use it instead of always hitting session storage
+  const session = currentSession || (stickySession && fetchSession());
 
   if (session) {
     // If there is a session, check if it is valid (e.g. "last activity" time should be within the "session idle time")


### PR DESCRIPTION
This reduces calls to session storage if a session already exists. Previously (for sticky sessions), it was calling `fetchSession()` (which fetches from session storage) on every `loadSession` call.
