### PR TITLE
feat: Reset initialEventTimestampSinceFlush, only track earliest event on new sessions

### DIFF
--- a/src/eventBuffer.ts
+++ b/src/eventBuffer.ts
@@ -180,8 +180,6 @@ export class EventBufferCompressionWorker implements IEventBuffer {
       args: [event],
     });
 
-    logger.log('Message posted to worker');
-
     // XXX: See note in `get length()`
     this.eventBufferItemLength++;
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -341,6 +341,7 @@ export class SentryReplay implements Integration {
     const url = `${window.location.origin}${urlPath}`;
 
     this.performanceEvents = [];
+    this.initialEventTimestampSinceFlush = null;
 
     // Reset context as well
     this.popEventContext();
@@ -708,9 +709,12 @@ export class SentryReplay implements Integration {
     const isMs = event.timestamp > 9999999999;
     const timestampInMs = isMs ? event.timestamp : event.timestamp * 1000;
 
+    // Only record earliest event if a new session was created, otherwise it
+    // shouldn't be relevant
     if (
-      !this.context.earliestEvent ||
-      timestampInMs < this.context.earliestEvent
+      this.newSessionCreated &&
+      (!this.context.earliestEvent ||
+        timestampInMs < this.context.earliestEvent)
     ) {
       this.context.earliestEvent = timestampInMs;
     }


### PR DESCRIPTION
* Forgot to reset `this.initialEventTimestampSinceFlush` when new session is created
* Only track `earliestEvent` if new session was created
