### PR TITLE
feat: Explicitly update session activity

### DIFF
--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -16,7 +16,7 @@ export interface CaptureReplayEventParams {
   /**
    * Timestamp of the event in milliseconds
    */
-  timestamp: number;
+  timestamp?: number;
   traceIds: string[];
   urls: string[];
 }
@@ -38,7 +38,7 @@ export function captureReplayEvent({
       ...(includeReplayStartTimestamp
         ? { replay_start_timestamp: initialState.timestamp / 1000 }
         : {}),
-      ...(timestamp ? { timestamp: timestamp / 1000 } : {}),
+      timestamp: (timestamp ? timestamp : new Date().getTime()) / 1000,
       error_ids: errorIds,
       trace_ids: traceIds,
       urls,

--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -4,20 +4,40 @@ import { REPLAY_EVENT_NAME } from '@/session/constants';
 import { InitialState } from '@/types';
 
 export interface CaptureReplayEventParams {
+  /**
+   * Initial state of the replay
+   */
   initialState: InitialState;
   /**
    * Include a timestamp that should be deemed as the "starting" timestamp of the
    * replay. This usually comes from a `window.performance` entry.
    */
   includeReplayStartTimestamp: boolean;
+  /**
+   * List of error ids contained in current recording segment
+   */
   errorIds: string[];
+
+  /**
+   * The current replay id
+   */
   replayId: string;
+  /**
+   * The current recording segment id
+   */
   segmentId: number;
   /**
    * Timestamp of the event in milliseconds
    */
-  timestamp?: number;
+  timestamp: number;
+
+  /**
+   * List of trace ids contained in current recording segment
+   */
   traceIds: string[];
+  /**
+   * List of URLs visisted in current recording segment
+   */
   urls: string[];
 }
 
@@ -38,7 +58,7 @@ export function captureReplayEvent({
       ...(includeReplayStartTimestamp
         ? { replay_start_timestamp: initialState.timestamp / 1000 }
         : {}),
-      timestamp: (timestamp ? timestamp : new Date().getTime()) / 1000,
+      timestamp: timestamp / 1000,
       error_ids: errorIds,
       trace_ids: traceIds,
       urls,

--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -5,6 +5,10 @@ import { InitialState } from '@/types';
 
 export interface CaptureReplayEventParams {
   initialState: InitialState;
+  /**
+   * Include a timestamp that should be deemed as the "starting" timestamp of the
+   * replay. This usually comes from a `window.performance` entry.
+   */
   includeReplayStartTimestamp: boolean;
   errorIds: string[];
   replayId: string;

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -217,8 +217,8 @@ describe('SentryReplay', () => {
     expect(replay).toHaveSentReplay(
       JSON.stringify([TEST_EVENT, hiddenBreadcrumb])
     );
-    // Session's last activity should be updated
-    expect(replay.session?.lastActivity).toBeGreaterThan(BASE_TIMESTAMP);
+    // Session's last activity should not be updated
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
     // events array should be empty
     expect(replay.eventBuffer?.length).toBe(0);
   });
@@ -244,8 +244,9 @@ describe('SentryReplay', () => {
     expect(replay.sendReplayRequest).toHaveBeenCalled();
     expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));
 
-    // Session's last activity should be updated
-    expect(replay.session?.lastActivity).toBeGreaterThan(BASE_TIMESTAMP);
+    // Session's last activity is not updated because we do not consider
+    // visibilitystate as user being active
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
     // events array should be empty
     expect(replay.eventBuffer?.length).toBe(0);
   });
@@ -261,9 +262,8 @@ describe('SentryReplay', () => {
     expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
     expect(replay).toHaveSentReplay(JSON.stringify([TEST_EVENT]));
 
-    // Right before sending a replay, we add memory usage and perf entries,
-    // which we are considering as an "activity" here.
-    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP + ELAPSED);
+    // No user activity to trigger an update
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
     expect(replay.session?.segmentId).toBe(1);
 
     // events array should be empty
@@ -293,7 +293,7 @@ describe('SentryReplay', () => {
 
     expect(replay).not.toHaveSentReplay();
 
-    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP + 16000);
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
     expect(replay.session?.segmentId).toBe(1);
     // events array should be empty
     expect(replay.eventBuffer?.length).toBe(0);

--- a/src/index.ts
+++ b/src/index.ts
@@ -855,7 +855,10 @@ export class SentryReplay implements Integration {
     timestamp,
   }: {
     timestamp?: number;
-  } = {}): CaptureReplayEventParams {
+  } = {}): Omit<
+    CaptureReplayEventParams,
+    'includeReplayStartTimestamp' | 'segment_id' | 'replay_id'
+  > {
     const initialState = this.initialState;
     if (
       this.initialState &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -208,6 +208,10 @@ export class SentryReplay implements Integration {
       return;
     }
 
+    // setup() is generally called on page load or manually - in both cases we
+    // should treat it as an activity
+    this.updateLastActivity();
+
     this.eventBuffer = createEventBuffer({
       useCompression: Boolean(this.options.useCompression),
     });
@@ -486,8 +490,6 @@ export class SentryReplay implements Integration {
       return;
     }
 
-    console.log(event);
-
     this.addUpdate(() => {
       // We need to clear existing events on a checkout, otherwise they are
       // incremental event updates and should be appended
@@ -541,7 +543,8 @@ export class SentryReplay implements Integration {
       category: 'ui.blur',
     });
 
-    this.updateLastActivity();
+    // Do not count blur as a user action -- it's part of the process of them
+    // leaving the page
     this.doChangeToBackgroundTasks(breadcrumb);
   };
 
@@ -553,6 +556,8 @@ export class SentryReplay implements Integration {
       category: 'ui.focus',
     });
 
+    // Do not count focus as a user action -- instead wait until they focus and
+    // interactive with page
     this.doChangeToForegroundTasks(breadcrumb);
   };
 
@@ -612,7 +617,6 @@ export class SentryReplay implements Integration {
         return;
       }
 
-      console.log(result);
       if (result.category === 'ui.click') {
         this.updateLastActivity();
       }

--- a/src/index.ts
+++ b/src/index.ts
@@ -348,7 +348,7 @@ export class SentryReplay implements Integration {
     this.initialEventTimestampSinceFlush = null;
 
     // Reset context as well
-    this.popEventContext();
+    this.clearContext();
     this.initialState = {
       timestamp: new Date().getTime(),
       url,
@@ -853,13 +853,23 @@ export class SentryReplay implements Integration {
   }
 
   /**
+   * Clear context
+   */
+  clearContext() {
+    this.context.errorIds.clear();
+    this.context.traceIds.clear();
+    this.context.urls = [];
+    this.context.earliestEvent = null;
+  }
+
+  /**
    * Return and clear context
    */
   popEventContext({
     timestamp,
   }: {
-    timestamp?: number;
-  } = {}): Omit<
+    timestamp: number;
+  }): Omit<
     CaptureReplayEventParams,
     'includeReplayStartTimestamp' | 'segmentId' | 'replayId'
   > {
@@ -880,10 +890,7 @@ export class SentryReplay implements Integration {
       urls: this.context.urls,
     };
 
-    this.context.errorIds.clear();
-    this.context.traceIds.clear();
-    this.context.urls = [];
-    this.context.earliestEvent = null;
+    this.clearContext();
 
     return context;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -857,7 +857,7 @@ export class SentryReplay implements Integration {
     timestamp?: number;
   } = {}): Omit<
     CaptureReplayEventParams,
-    'includeReplayStartTimestamp' | 'segment_id' | 'replay_id'
+    'includeReplayStartTimestamp' | 'segmentId' | 'replayId'
   > {
     const initialState = this.initialState;
     if (


### PR DESCRIPTION
Instead of always updating session activity on every flush, do it on explicit user actions (e.g. click and history changes).
