### PR TITLE
feat: Do not ignore ingest host on sentry.io

### DIFF
--- a/src/util/isIngestHost.ts
+++ b/src/util/isIngestHost.ts
@@ -6,5 +6,11 @@ import { getCurrentHub } from '@sentry/core';
 export function isIngestHost(targetHost: string) {
   const { protocol, host } = getCurrentHub().getClient()?.getDsn() || {};
 
+  // XXX: Special case when this integration is used by Sentry on `sentry.io`
+  // We would like to capture network requests made to our ingest endpoints for debugging
+  if (window.location.host === 'sentry.io') {
+    return false;
+  }
+
   return targetHost.startsWith(`${protocol}://${host}`);
 }


### PR DESCRIPTION
We want to see network requests made to our ingest endpoint when Replays SDK is used on our SaaS.

Closes https://github.com/getsentry/sentry-replay/issues/196