### PR TITLE
ref: Rename defaults for privacy options

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,6 @@ replay.setup(); // Start recording again
 | `captureOnlyOnError` | `boolean` | `false` | Only capture the recording when an error happens. |
 | `replaysSamplingRate` | `number` | `1.0` | The rate at which to sample replays. (1.0 will collect all replays, 0 will collect no replays). |
 | `recordingConfig.maskAllInputs` | `boolean` | `true` | Mask all `<input>` elements |
-| `recordingConfig.blockClass` | `string` | `'sr-block'` | Redact all elements with the class name `sr-block` |
-| `recordingConfig.ignoreClass` | `string` | `'sr-ignore'` | Ignores all elements with the class name `sr-ignore` |
-| `recordingConfig.maskTextClass` | `string` | `'sr-mask'` | Mask all elements with the class name `sr-ignore` |
+| `recordingConfig.blockClass` | `string` | `'sentry-block'` | Redact all elements with the class name `sentry-block` |
+| `recordingConfig.ignoreClass` | `string` | `'sentry-ignore'` | Ignores all elements with the class name `sentry-ignore` |
+| `recordingConfig.maskTextClass` | `string` | `'sentry-mask'` | Mask all elements with the class name `sentry-ignore` |

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -90,7 +90,7 @@ describe('SentryReplay', () => {
       Object {
         "blockClass": "sentry-block",
         "emit": [Function],
-        "ignoreClass": "sr-test",
+        "ignoreClass": "sentry-test-ignore",
         "maskAllInputs": true,
         "maskTextClass": "sentry-mask",
       }

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -88,11 +88,11 @@ describe('SentryReplay', () => {
   it('calls rrweb.record with custom options', async () => {
     expect(mockRecord.mock.calls[0][0]).toMatchInlineSnapshot(`
       Object {
-        "blockClass": "sr-block",
+        "blockClass": "sentry-block",
         "emit": [Function],
         "ignoreClass": "sr-test",
         "maskAllInputs": true,
-        "maskTextClass": "sr-mask",
+        "maskTextClass": "sentry-mask",
       }
     `);
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -149,9 +149,9 @@ export class SentryReplay implements Integration {
     replaysSamplingRate = 1.0,
     recordingConfig: {
       maskAllInputs = true,
-      blockClass = 'sr-block',
-      ignoreClass = 'sr-ignore',
-      maskTextClass = 'sr-mask',
+      blockClass = 'sentry-block',
+      ignoreClass = 'sentry-ignore',
+      maskTextClass = 'sentry-mask',
       ...recordingOptions
     } = {},
   }: SentryReplayConfiguration = {}) {

--- a/test/mocks/mockSdk.ts
+++ b/test/mocks/mockSdk.ts
@@ -39,7 +39,7 @@ class MockTransport implements Transport {
 export function mockSdk({
   replayOptions = {
     stickySession: true,
-    recordingConfig: { ignoreClass: 'sr-test' },
+    recordingConfig: { ignoreClass: 'sentry-test-ignore' },
   },
   sentryOptions = {
     dsn: 'https://dsn@ingest.f00.f00/1',


### PR DESCRIPTION
Rename the default class names for privacy-related options (e.g. `recordingConfig.blockClass`). Changed prefix from `sr-` to `sentry-`.
