### PR TITLE
ref: Rename `setup` and `destroy` methods to `start` and `stop`

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ replay.start(); // Start recording again
 | `flushMinDelay` | `number` | `5000` | The minimum time to wait (in ms) before sending the recording payload. The payload is sent if `flushMinDelay` ms have elapsed between two events. |
 | `flushMaxDelay` | `number` | `15000` | The maximum time to wait (in ms) when sending the recording payload. The payload is sent if events occur at an interval less than `flushMinDelay` and `flushMaxDelay` ms have elapsed since the last time a payload was sent. |
 | `initialFlushDelay` | `number` | `5000` | The amount of time to wait (in ms) before sending the initial recording payload. This helps drop recordings where users visit and close the page quickly. |
-| `startImmediately` | `boolean` | `true` | Should recording start immediately upon initialization? |
 | `stickySession` | `boolean` | `true` | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well. |
 | `useCompression` | `boolean` | `true` | Uses `WebWorkers` (if available) to compress the recording payload before uploading to Sentry. |
 | `captureOnlyOnError` | `boolean` | `false` | Only capture the recording when an error happens. |

--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ Sentry.init({
 
 ### Stopping Replays
 
-To stop replays you can call the `destroy()` method on the integration instance. It's possible to resume recording by calling `setup()`.
+To stop replays you can call the `stop()` method on the integration instance. It's possible to resume recording by calling `setup()`.
 
 ```javascript
 
 const replay = new SentryReplay(); // This will begin recording replays
 
-replay.destroy(); // Stop recording
+replay.stop(); // Stop recording
 
-replay.setup(); // Start recording again
+replay.start(); // Start recording again
 ```
 
 ## Configuration
@@ -66,6 +66,7 @@ replay.setup(); // Start recording again
 | `flushMinDelay` | `number` | `5000` | The minimum time to wait (in ms) before sending the recording payload. The payload is sent if `flushMinDelay` ms have elapsed between two events. |
 | `flushMaxDelay` | `number` | `15000` | The maximum time to wait (in ms) when sending the recording payload. The payload is sent if events occur at an interval less than `flushMinDelay` and `flushMaxDelay` ms have elapsed since the last time a payload was sent. |
 | `initialFlushDelay` | `number` | `5000` | The amount of time to wait (in ms) before sending the initial recording payload. This helps drop recordings where users visit and close the page quickly. |
+| `startImmediately` | `boolean` | `true` | Should recording start immediately upon initialization? |
 | `stickySession` | `boolean` | `true` | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well. |
 | `useCompression` | `boolean` | `true` | Uses `WebWorkers` (if available) to compress the recording payload before uploading to Sentry. |
 | `captureOnlyOnError` | `boolean` | `false` | Only capture the recording when an error happens. |

--- a/src/flush.test.ts
+++ b/src/flush.test.ts
@@ -109,7 +109,7 @@ afterEach(async () => {
 });
 
 afterAll(() => {
-  replay && replay.destroy();
+  replay && replay.stop();
 });
 
 it('flushes twice after multiple flush() calls)', async () => {

--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -69,7 +69,7 @@ describe('SentryReplay (capture only on error)', () => {
   });
 
   afterAll(() => {
-    replay && replay.destroy();
+    replay && replay.stop();
   });
 
   it('uploads a replay when captureException is called', async () => {

--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -60,7 +60,7 @@ describe('SentryReplay (no sticky)', () => {
   });
 
   afterAll(() => {
-    replay && replay.destroy();
+    replay && replay.stop();
   });
 
   it('creates a new session and triggers a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -82,7 +82,7 @@ describe('SentryReplay', () => {
   });
 
   afterAll(() => {
-    replay && replay.destroy();
+    replay && replay.stop();
   });
 
   it('calls rrweb.record with custom options', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,7 +140,6 @@ export class SentryReplay implements Integration {
   session: Session | undefined;
 
   constructor({
-    startImmediately = true,
     flushMinDelay = 5000,
     flushMaxDelay = 15000,
     initialFlushDelay = 5000,
@@ -165,7 +164,6 @@ export class SentryReplay implements Integration {
     };
 
     this.options = {
-      startImmediately,
       flushMinDelay,
       flushMaxDelay,
       stickySession,
@@ -192,10 +190,6 @@ export class SentryReplay implements Integration {
    * other global event processors to finish
    */
   setupOnce() {
-    if (!this.options.startImmediately) {
-      return;
-    }
-
     // XXX: See method comments above
     window.setTimeout(() => this.start());
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -140,6 +140,7 @@ export class SentryReplay implements Integration {
   session: Session | undefined;
 
   constructor({
+    startImmediately = true,
     flushMinDelay = 5000,
     flushMaxDelay = 15000,
     initialFlushDelay = 5000,
@@ -164,6 +165,7 @@ export class SentryReplay implements Integration {
     };
 
     this.options = {
+      startImmediately,
       flushMinDelay,
       flushMaxDelay,
       stickySession,
@@ -190,8 +192,12 @@ export class SentryReplay implements Integration {
    * other global event processors to finish
    */
   setupOnce() {
+    if (!this.options.startImmediately) {
+      return;
+    }
+
     // XXX: See method comments above
-    window.setTimeout(() => this.setup());
+    window.setTimeout(() => this.start());
   }
 
   /**
@@ -199,7 +205,7 @@ export class SentryReplay implements Integration {
    *
    * Creates or loads a session, attaches listeners to varying events (DOM, PerformanceObserver, Recording, Sentry SDK, etc)
    */
-  setup() {
+  start() {
     this.loadSession({ expiry: SESSION_IDLE_DURATION });
 
     // If there is no session, then something bad has happened - can't continue
@@ -299,7 +305,7 @@ export class SentryReplay implements Integration {
   /**
    * Currently, this needs to be manually called (e.g. for tests). Sentry SDK does not support a teardown
    */
-  destroy() {
+  stop() {
     logger.log('Stopping Replays');
     this.isEnabled = false;
     this.removeListeners();

--- a/src/stop.test.ts
+++ b/src/stop.test.ts
@@ -64,7 +64,7 @@ describe('SentryReplay - stop', () => {
   });
 
   afterAll(() => {
-    replay && replay.destroy();
+    replay && replay.stop();
   });
 
   it('does not upload replay if it was stopped and can resume replays afterwards', async () => {
@@ -80,7 +80,7 @@ describe('SentryReplay - stop', () => {
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
 
     // stop replays
-    replay.destroy();
+    replay.stop();
 
     // Pretend 5 seconds have passed
     jest.advanceTimersByTime(ELAPSED);
@@ -97,7 +97,7 @@ describe('SentryReplay - stop', () => {
     expect(replay.eventBuffer).toBe(null);
 
     // re-enable replay
-    replay.setup();
+    replay.start();
 
     jest.advanceTimersByTime(ELAPSED);
 
@@ -135,7 +135,7 @@ describe('SentryReplay - stop', () => {
     expect(replay.eventBuffer?.length).toBe(1);
 
     // stop replays
-    replay.destroy();
+    replay.stop();
 
     expect(replay.eventBuffer?.length).toBe(undefined);
 
@@ -148,10 +148,10 @@ describe('SentryReplay - stop', () => {
 
   it('does not call core SDK `addInstrumentationHandler` after initial setup', async function () {
     // NOTE: We clear addInstrumentationHandler mock after every test
-    replay.destroy();
-    replay.setup();
-    replay.destroy();
-    replay.setup();
+    replay.stop();
+    replay.start();
+    replay.stop();
+    replay.start();
 
     expect(mockAddInstrumentationHandler).not.toHaveBeenCalled();
   });

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,11 +68,6 @@ export interface SentryReplayPluginOptions {
   stickySession?: boolean;
 
   /**
-   * Should the integration start recording immediately?
-   */
-  startImmediately?: boolean;
-
-  /**
    * Attempt to use compression when web workers are available
    *
    * (default is true)

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,6 +68,11 @@ export interface SentryReplayPluginOptions {
   stickySession?: boolean;
 
   /**
+   * Should the integration start recording immediately?
+   */
+  startImmediately?: boolean;
+
+  /**
    * Attempt to use compression when web workers are available
    *
    * (default is true)


### PR DESCRIPTION
`start()` and `stop()` are more straightforward names.

Also add `startImmediately` configuration item to start upon
initialization. (defaults to true).
