### PR TITLE
feat: Use `lodash.debounce` instead of custom debounce logic

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@sentry/browser": "^7.7.0",
     "@size-limit/preset-big-lib": "^7.0.8",
     "@types/jest": "^28.1.1",
+    "@types/lodash.debounce": "^4.0.7",
     "@types/lodash.throttle": "^4.1.7",
     "@types/node": "^16.0.0",
     "@types/pako": "^2.0.0",
@@ -72,6 +73,7 @@
     "@sentry/core": "^7.7.0",
     "@sentry/types": "^7.7.0",
     "@sentry/utils": "^7.7.0",
+    "lodash.debounce": "^4.0.8",
     "lodash.throttle": "^4.1.1",
     "pako": "^2.0.4",
     "rrweb": "^1.1.3"

--- a/src/flush.test.ts
+++ b/src/flush.test.ts
@@ -148,6 +148,7 @@ it('long first flush enqueues following events', async () => {
 
   // flush #1 @ t=0s - due to blur
   window.dispatchEvent(new Event('blur'));
+  expect(replay.flush).toHaveBeenCalledTimes(1);
   expect(replay.runFlush).toHaveBeenCalledTimes(1);
 
   // This will attempt to flush in 5 seconds (flushMinDelay)

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,6 +8,7 @@ import {
 import { Breadcrumb, Event, Integration } from '@sentry/types';
 import { addInstrumentationHandler } from '@sentry/utils';
 import { createEnvelope, serializeEnvelope } from '@sentry/utils';
+import debounce from 'lodash.debounce';
 import throttle from 'lodash.throttle';
 import { EventType, record } from 'rrweb';
 
@@ -27,7 +28,6 @@ import { getSession } from './session/getSession';
 import { Session } from './session/Session';
 import createBreadcrumb from './util/createBreadcrumb';
 import { createPayload } from './util/createPayload';
-import { isExpired } from './util/isExpired';
 import { isSessionExpired } from './util/isSessionExpired';
 import { logger } from './util/logger';
 import {
@@ -85,11 +85,6 @@ export class SentryReplay implements Integration {
   readonly options: SentryReplayPluginOptions;
 
   /**
-   * setTimeout id used for debouncing sending rrweb attachments
-   */
-  private timeout: number;
-
-  /**
    * The timestamp of the first event since the last flush. This is used to
    * determine if the maximum allowed time has passed before events should be
    * flushed again.
@@ -100,6 +95,8 @@ export class SentryReplay implements Integration {
 
   private retryCount = 0;
   private retryInterval = BASE_RETRY_INTERVAL;
+
+  private debouncedFlush: ReturnType<typeof debounce>;
 
   /**
    * Flag when a new session has been created. Captured replay events behave
@@ -187,6 +184,14 @@ export class SentryReplay implements Integration {
       // content masked.
       this.recordingOptions.maskTextSelector = '*';
     }
+
+    this.debouncedFlush = debounce(
+      () => this.flush(),
+      this.options.flushMinDelay,
+      {
+        maxWait: this.options.flushMaxDelay,
+      }
+    );
   }
 
   /**
@@ -262,11 +267,6 @@ export class SentryReplay implements Integration {
       this.initialEventTimestampSinceFlush = now;
     }
 
-    // Do not finish the replay event if we receive a new replay event
-    if (this.timeout) {
-      window.clearTimeout(this.timeout);
-    }
-
     // We need to always run `cb` (e.g. in the case of captureOnlyOnError == true)
     const cbResult = cb?.();
 
@@ -282,27 +282,7 @@ export class SentryReplay implements Integration {
       return;
     }
 
-    const flushMaxDelayExceeded = isExpired(
-      this.initialEventTimestampSinceFlush,
-      this.options.flushMaxDelay,
-      now
-    );
-
-    // If `flushMaxDelayExceeded` is true, then we should finish the replay event immediately,
-    // Otherwise schedule it to be finished in `this.options.flushMinDelay`
-    if (flushMaxDelayExceeded) {
-      logger.log('replay max delay exceeded, finishing replay event');
-      this.flush();
-      return;
-    }
-
-    // Set timer to finish replay event and send replay attachment to
-    // Sentry. Will be cancelled if an event happens before `flushMinDelay`
-    // elapses.
-    this.timeout = window.setTimeout(() => {
-      logger.log('replay timeout exceeded, finishing replay event');
-      this.flush();
-    }, this.options.flushMinDelay);
+    this.debouncedFlush();
   }
 
   /**
@@ -988,7 +968,7 @@ export class SentryReplay implements Integration {
     // Since flushing, ensure other queued flushes are cancelled
     // We do this regardless of having a queued flush since the event updates
     // will be handled by queued flush
-    clearTimeout(this.timeout);
+    this.debouncedFlush?.cancel();
 
     // No existing flush in progress, proceed with flushing.
     // this.flushLock acts as a lock so that future calls to `flush()`

--- a/yarn.lock
+++ b/yarn.lock
@@ -899,6 +899,13 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
   integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
+"@types/lodash.debounce@^4.0.7":
+  version "4.0.7"
+  resolved "https://registry.yarnpkg.com/@types/lodash.debounce/-/lodash.debounce-4.0.7.tgz#0285879defb7cdb156ae633cecd62d5680eded9f"
+  integrity sha512-X1T4wMZ+gT000M2/91SYj0d/7JfeNZ9PeeOldSNoE/lunLeQXKvkmIumI29IaKMotU/ln/McOIvgzZcQ/3TrSA==
+  dependencies:
+    "@types/lodash" "*"
+
 "@types/lodash.throttle@^4.1.7":
   version "4.1.7"
   resolved "https://registry.yarnpkg.com/@types/lodash.throttle/-/lodash.throttle-4.1.7.tgz#4ef379eb4f778068022310ef166625f420b6ba58"
@@ -3159,6 +3166,11 @@ locate-path@^5.0.0:
   integrity sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
   dependencies:
     p-locate "^4.1.0"
+
+lodash.debounce@^4.0.8:
+  version "4.0.8"
+  resolved "https://registry.yarnpkg.com/lodash.debounce/-/lodash.debounce-4.0.8.tgz#82d79bff30a67c4005ffd5e2515300ad9ca4d7af"
+  integrity sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==
 
 lodash.memoize@4.x:
   version "4.1.2"


### PR DESCRIPTION
I was not able to write a repro test case for this but on the browser I was seeing runFlush still being called multiple times after `flushMaxDelay` was reached. Switching to lodash seems to resolve this issue.
