### PR TITLE
ref: Change `replay_event` timestamp

### DIFF
--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -271,10 +271,10 @@ describe('SentryReplay (capture only on error)', () => {
     expect(captureEventMock).toHaveBeenCalledWith(
       expect.objectContaining({
         replay_start_timestamp: BASE_TIMESTAMP / 1000,
-        // the exception happened roughly 5 seconds after BASE_TIMESTAMP (i.e. 5
-        // seconds after root replay event). extra time is likely due to async
-        // of `addMemoryEntry()`
-        timestamp: expect.closeTo((BASE_TIMESTAMP + 5000) / 1000, 1),
+        // the exception happens roughly 5 seconds after BASE_TIMESTAMP and
+        // after `sendReplayRequest` which is mocked to resolve after 7 seconds.
+        // extra time is likely due to async of `addMemoryEntry()`
+        timestamp: expect.closeTo((BASE_TIMESTAMP + 5000 + 7000) / 1000, 1),
         type: 'replay_event',
         error_ids: [expect.any(String)],
         trace_ids: [],

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -463,7 +463,8 @@ describe('SentryReplay', () => {
         replay_id: expect.any(String),
         replay_start_timestamp: BASE_TIMESTAMP / 1000,
         segment_id: 0,
-        timestamp: (BASE_TIMESTAMP + 5000) / 1000,
+        // 20seconds = Add up all of the previous `advanceTimers()`
+        timestamp: (BASE_TIMESTAMP + 20000) / 1000 + 0.06,
         trace_ids: [],
         type: 'replay_event',
         urls: ['http://localhost/'],

--- a/src/index.ts
+++ b/src/index.ts
@@ -929,9 +929,6 @@ export class SentryReplay implements Integration {
     // Only attach memory event if eventBuffer is not empty
     await this.addMemoryEntry();
 
-    // Save the timestamp before sending replay because `captureEvent` should
-    // only be called after successfully uploading a replay
-    const timestamp = new Date().getTime();
     // NOTE: Copy values from instance members, as it's possible they could
     // change before the flush finishes.
     const replayId = this.session.id;
@@ -950,7 +947,7 @@ export class SentryReplay implements Integration {
 
       // The below will only happen after successfully sending replay //
       captureReplayEvent({
-        ...this.popEventContext({ timestamp }),
+        ...this.popEventContext({ timestamp: new Date().getTime() }),
         replayId,
         segmentId,
         includeReplayStartTimestamp: newSessionCreated,


### PR DESCRIPTION
Previously we used the timestamp *before* calling two async fns: getting data from event buffer and sending replay. Intended to keep timestamps roughly the same between `replay_event` and `replay_recording`. Instead, just use current time when we capture `replay_event`.
