### PR TITLE
feat: Include sdk version when capturing events

### DIFF
--- a/config/rollup.config.core.ts
+++ b/config/rollup.config.core.ts
@@ -30,6 +30,7 @@ const config = defineConfig({
       // __SENTRY_DEBUG__ should be save to replace in any case, so no checks for assignments necessary
       preventAssignment: false,
       values: {
+        __SENTRY_REPLAY_VERSION__: JSON.stringify(pkg.version),
         // @ts-expect-error not gonna deal with types here
         __SENTRY_DEBUG__: !IS_PRODUCTION,
       },

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,6 +1,9 @@
 import { SentryReplay } from '@';
 import { Session } from '@/session/Session';
 
+// @ts-expect-error TS error, this is replaced in prod builds bc of rollup
+global.__SENTRY_REPLAY_VERSION__ = 'version:Test';
+
 const ENVELOPE_URL_REGEX = new RegExp(
   'https://ingest.f00.f00/api/1/envelope/\\?sentry_key=dsn&sentry_version=7'
 );

--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -64,7 +64,7 @@ export function captureReplayEvent({
       urls,
       replay_id,
       segment_id,
-      sdk_version: __SENTRY_REPLAY_VERSION__,
+      replay_sdk_version: __SENTRY_REPLAY_VERSION__,
     },
     { event_id: replay_id }
   );

--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -1,4 +1,4 @@
-import { captureEvent } from '@sentry/core';
+import { captureEvent, getCurrentHub } from '@sentry/core';
 
 import { REPLAY_EVENT_NAME } from '@/session/constants';
 import { InitialState } from '@/types';
@@ -51,6 +51,7 @@ export function captureReplayEvent({
   traceIds,
   urls,
 }: CaptureReplayEventParams) {
+  getCurrentHub()?.setTag('replay_sdk_version', __SENTRY_REPLAY_VERSION__);
   captureEvent(
     {
       // @ts-expect-error replay_event is a new event type
@@ -64,7 +65,6 @@ export function captureReplayEvent({
       urls,
       replay_id,
       segment_id,
-      replay_sdk_version: __SENTRY_REPLAY_VERSION__,
     },
     { event_id: replay_id }
   );

--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -64,6 +64,7 @@ export function captureReplayEvent({
       urls,
       replay_id,
       segment_id,
+      sdk_version: __SENTRY_REPLAY_VERSION__,
     },
     { event_id: replay_id }
   );

--- a/src/index.ts
+++ b/src/index.ts
@@ -1018,7 +1018,6 @@ export class SentryReplay implements Integration {
       events,
       headers: {
         segment_id,
-        sdk_version: __SENTRY_REPLAY_VERSION__,
       },
     });
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -1018,6 +1018,7 @@ export class SentryReplay implements Integration {
       events,
       headers: {
         segment_id,
+        sdk_version: __SENTRY_REPLAY_VERSION__,
       },
     });
 
@@ -1025,7 +1026,10 @@ export class SentryReplay implements Integration {
       {
         event_id,
         sent_at: new Date().toISOString(),
-        sdk: { name: 'sentry.javascript.integration.replay', version: '1.0.0' },
+        sdk: {
+          name: 'sentry.javascript.integration.replay',
+          version: __SENTRY_REPLAY_VERSION__,
+        },
       },
       [
         [

--- a/src/types.ts
+++ b/src/types.ts
@@ -36,6 +36,10 @@ export interface WorkerRequest {
   args: any[];
 }
 
+declare global {
+  const __SENTRY_REPLAY_VERSION__: string;
+}
+
 /**
  * The response from the worker
  */


### PR DESCRIPTION
Update build script to include actual package version and send as tag for `replay_event` and send in headers for `replay_recording`


Closes #202 