### PR TITLE
feat: Add some debugging breadcrumbs for internal sentry users

### DIFF
--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -2,6 +2,7 @@ import { captureEvent, withScope } from '@sentry/core';
 
 import { REPLAY_EVENT_NAME } from '@/session/constants';
 import { InitialState } from '@/types';
+import { addInternalBreadcrumb } from '@/util/addInternalBreadcrumb';
 
 export interface CaptureReplayEventParams {
   /**
@@ -51,6 +52,12 @@ export function captureReplayEvent({
   traceIds,
   urls,
 }: CaptureReplayEventParams) {
+  if (segment_id !== 0 && includeReplayStartTimestamp) {
+    addInternalBreadcrumb({
+      message: `Including replay_start_timestamp on non-initial segment (id: ${segment_id})`,
+    });
+  }
+
   withScope((scope) => {
     scope.setTag('replay_sdk_version', __SENTRY_REPLAY_VERSION__);
     captureEvent(

--- a/src/index.ts
+++ b/src/index.ts
@@ -26,6 +26,7 @@ import {
 import { deleteSession } from './session/deleteSession';
 import { getSession } from './session/getSession';
 import { Session } from './session/Session';
+import { addInternalBreadcrumb } from './util/addInternalBreadcrumb';
 import createBreadcrumb from './util/createBreadcrumb';
 import { createPayload } from './util/createPayload';
 import { isSessionExpired } from './util/isSessionExpired';
@@ -455,6 +456,15 @@ export class SentryReplay implements Integration {
     // XXX: Is it safe to assume that all other events are error events?
     // @ts-expect-error: Type 'undefined' is not assignable to type 'string'.ts(2345)
     this.context.errorIds.add(event.event_id);
+
+    if (event.exception) {
+      const exc = event.exception?.values?.[0];
+      addInternalBreadcrumb({
+        message: `Tagging event (${event.event_id}) - ${
+          exc?.type || 'Unknown'
+        }: ${exc?.value || 'n/a'}`,
+      });
+    }
 
     // Need to be very careful that this does not cause an infinite loop
     if (
@@ -898,6 +908,14 @@ export class SentryReplay implements Integration {
    * due to the buffered performance observer events.
    */
   async runFlush() {
+    const stack = new Error('trace').stack?.split('\n') || [];
+
+    addInternalBreadcrumb({
+      message: `runFlush (${this.session?.segmentId})
+
+${stack.slice(1).join('\n')}`,
+    });
+
     if (!this.session) {
       console.error(new Error('[Sentry]: No transaction, no replay'));
       return;

--- a/src/util/addInternalBreadcrumb.ts
+++ b/src/util/addInternalBreadcrumb.ts
@@ -1,0 +1,23 @@
+import { addBreadcrumb } from '@sentry/core';
+
+import { isInternal } from './isInternal';
+
+/**
+ * Wrapper for core SDK's `addBreadcrumb` only when used on `sentry.io`
+ */
+export function addInternalBreadcrumb(
+  arg: Parameters<typeof addBreadcrumb>[0]
+) {
+  if (!isInternal()) {
+    return;
+  }
+
+  const { category, level, message, ...rest } = arg;
+
+  addBreadcrumb({
+    category: category || 'console',
+    level: level || 'debug',
+    message: `[debug]: ${message}`,
+    ...rest,
+  });
+}

--- a/src/util/isIngestHost.ts
+++ b/src/util/isIngestHost.ts
@@ -1,5 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 
+import { isInternal } from './isInternal';
+
 /**
  * Checks is `targetHost` is a Sentry ingestion host
  */
@@ -8,7 +10,7 @@ export function isIngestHost(targetHost: string) {
 
   // XXX: Special case when this integration is used by Sentry on `sentry.io`
   // We would like to capture network requests made to our ingest endpoints for debugging
-  if (window.location.host === 'sentry.io') {
+  if (isInternal()) {
     return false;
   }
 

--- a/src/util/isInternal.ts
+++ b/src/util/isInternal.ts
@@ -3,5 +3,5 @@
  * (e.g. on https://sentry.io )
  */
 export function isInternal() {
-  return window.location.host === 'sentry.io';
+  return ['sentry.io', 'dev.getsentry.net'].includes(window.location.host);
 }

--- a/src/util/isInternal.ts
+++ b/src/util/isInternal.ts
@@ -1,0 +1,7 @@
+/**
+ * Returns true if we are currently recording an internal to Sentry replay
+ * (e.g. on https://sentry.io )
+ */
+export function isInternal() {
+  return window.location.host === 'sentry.io';
+}


### PR DESCRIPTION
Debugging breadcrumbs only when used on `sentry.io`
