### PR TITLE
feat: Remove throttled flush in favor of only using debounced flush

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "@sentry/types": "^7.7.0",
     "@sentry/utils": "^7.7.0",
     "lodash.debounce": "^4.0.8",
-    "lodash.throttle": "^4.1.1",
     "pako": "^2.0.4",
     "rrweb": "^1.1.3"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -897,6 +897,8 @@ export class SentryReplay implements Integration {
    *
    * Performance events are only added right before flushing - this is
    * due to the buffered performance observer events.
+   *
+   * Should never be called directly, only by `flush`
    */
   async runFlush() {
     if (!this.session) {
@@ -966,9 +968,7 @@ export class SentryReplay implements Integration {
       return;
     }
 
-    // Since flushing, ensure other queued flushes are cancelled
-    // We do this regardless of having a queued flush since the event updates
-    // will be handled by queued flush
+    // A flush is about to happen, cancel any queued flushes
     this.debouncedFlush?.cancel();
 
     // No existing flush in progress, proceed with flushing.

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,6 +281,8 @@ export class SentryReplay implements Integration {
       return;
     }
 
+    // addUpdate is called quite frequently - use debouncedFlush so that it
+    // respects the flush delays and does not flush immediately
     this.debouncedFlush();
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3182,11 +3182,6 @@ lodash.merge@^4.6.2:
   resolved "https://registry.yarnpkg.com/lodash.merge/-/lodash.merge-4.6.2.tgz#558aa53b43b661e1925a0afdfa36a9a1085fe57a"
   integrity sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==
 
-lodash.throttle@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/lodash.throttle/-/lodash.throttle-4.1.1.tgz#c23e91b710242ac70c37f1e1cda9274cc39bf2f4"
-  integrity sha512-wIkUCfVKpVsWo3JSZlc+8MB5it+2AN5W8J7YVMST30UrvcQNZ1Okbj+rbVniijTWE6FGYy4XJq/rHkas8qJMLQ==
-
 log-update@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/log-update/-/log-update-4.0.0.tgz#589ecd352471f2a1c0c570287543a64dfd20e0a1"


### PR DESCRIPTION
A debounced flush was added in https://github.com/getsentry/sentry-replay/pull/210 -- remove the throttled flush call in favor of the debounced version. This will give a more consistent flushing behavior by using only one debounced flush. The throttle was also set at 1 second, which is a bit too close in time to the previous flush.
