### PR TITLE
feat: Cancel `debouncedFlush` when queueing up initial flush

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -522,9 +522,14 @@ export class SentryReplay implements Integration {
       // capturing replays of users that immediately close the window.
       setTimeout(() => this.conditionalFlush(), this.options.initialFlushDelay);
 
-      // Cancel any previously queued flushes to ensure the checkout segment is
-      // first. This can happen because there's no guarantee that a recording
-      // event happens first.
+      // Cancel any previously debounced flushes to ensure there are no [near]
+      // simultaneous flushes happening. The latter request should be
+      // insignificant in this case, so wait for additional user interaction to
+      // trigger a new flush.
+      //
+      // This can happen because there's no guarantee that a recording event
+      // happens first. e.g. a mouse click can happen and trigger a debounced
+      // flush before the checkout.
       this.debouncedFlush?.cancel();
 
       return true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -522,6 +522,11 @@ export class SentryReplay implements Integration {
       // capturing replays of users that immediately close the window.
       setTimeout(() => this.conditionalFlush(), this.options.initialFlushDelay);
 
+      // Cancel any previously queued flushes to ensure the checkout segment is
+      // first. This can happen because there's no guarantee that a recording
+      // event happens first.
+      this.debouncedFlush?.cancel();
+
       return true;
     });
   };


### PR DESCRIPTION
The recording initial snapshot is not guaranteed to happen before an event that is captured by our core SDK. To ensure that the initial snapshot is the first segment, cancel any debouncedFlush calls when queueing up the flush for the initial snapshot.
