### PR TITLE
ref: Rename exported integration from `SentryReplay` to `Replay`

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,16 +27,15 @@ yarn add @sentry/browser @sentry/replay
 To set up the integration add the following to your Sentry initialization. Several options are supported and passable via the integration constructor.
 See the rrweb documentation for advice on configuring these values.
 
-
 ```javascript
 import * as Sentry from '@sentry/browser';
-import { SentryReplay } from '@sentry/replay';
+import { Replay } from '@sentry/replay';
 
 Sentry.init({
   dsn: '__DSN__',
   integrations: [
-    new SentryReplay({
-      maskAllText:  true, // Will mask all text strings
+    new Replay({
+      maskAllText: true, // Will mask all text strings
       recordingConfig: {
         maskAllInputs: false, // Default is true
       },
@@ -46,33 +45,31 @@ Sentry.init({
 });
 ```
 
-### Stop Recording 
+### Stop Recording
 
 Replay recording only starts automatically when it is included in the `integrations` key when calling `Sentry.init`. Otherwise you can initialize the plugin and manually call the `start()` method on the integration instance. To stop recording you can call the `stop()`.
 
 ```javascript
-
-const replay = new SentryReplay(); // This will *NOT* begin recording replays
+const replay = new Replay(); // This will *NOT* begin recording replays
 
 replay.start(); // Start recording
 
 replay.stop(); // Stop recording
-
 ```
 
 ## Configuration
 
-| key | type | default | description |
-| --- | ---- | ------- | ----------- |
-| `flushMinDelay` | `number` | `5000` | The minimum time to wait (in ms) before sending the recording payload. The payload is sent if `flushMinDelay` ms have elapsed between two events. |
-| `flushMaxDelay` | `number` | `15000` | The maximum time to wait (in ms) when sending the recording payload. The payload is sent if events occur at an interval less than `flushMinDelay` and `flushMaxDelay` ms have elapsed since the last time a payload was sent. |
-| `initialFlushDelay` | `number` | `5000` | The amount of time to wait (in ms) before sending the initial recording payload. This helps drop recordings where users visit and close the page quickly. |
-| `maskAllText` | `boolean` | `false` | Mask *all* text strings with `*`. |
-| `replaysSamplingRate` | `number` | `1.0` | The rate at which to sample replays. (1.0 will collect all replays, 0 will collect no replays). |
-| `stickySession` | `boolean` | `true` | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well. |
-| `useCompression` | `boolean` | `true` | Uses `WebWorkers` (if available) to compress the recording payload before uploading to Sentry. |
-| `captureOnlyOnError` | `boolean` | `false` | Only capture the recording when an error happens. |
-| `recordingConfig.maskAllInputs` | `boolean` | `true` | Mask all `<input>` elements |
-| `recordingConfig.blockClass` | `string` | `'sentry-block'` | Redact all elements with the class name `sentry-block` |
-| `recordingConfig.ignoreClass` | `string` | `'sentry-ignore'` | Ignores all elements with the class name `sentry-ignore` |
-| `recordingConfig.maskTextClass` | `string` | `'sentry-mask'` | Mask all elements with the class name `sentry-ignore` |
+| key                             | type      | default           | description                                                                                                                                                                                                                   |
+| ------------------------------- | --------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `flushMinDelay`                 | `number`  | `5000`            | The minimum time to wait (in ms) before sending the recording payload. The payload is sent if `flushMinDelay` ms have elapsed between two events.                                                                             |
+| `flushMaxDelay`                 | `number`  | `15000`           | The maximum time to wait (in ms) when sending the recording payload. The payload is sent if events occur at an interval less than `flushMinDelay` and `flushMaxDelay` ms have elapsed since the last time a payload was sent. |
+| `initialFlushDelay`             | `number`  | `5000`            | The amount of time to wait (in ms) before sending the initial recording payload. This helps drop recordings where users visit and close the page quickly.                                                                     |
+| `maskAllText`                   | `boolean` | `false`           | Mask _all_ text strings with `*`.                                                                                                                                                                                             |
+| `replaysSamplingRate`           | `number`  | `1.0`             | The rate at which to sample replays. (1.0 will collect all replays, 0 will collect no replays).                                                                                                                               |
+| `stickySession`                 | `boolean` | `true`            | Keep track of the user across page loads. Note a single user using multiple tabs will result in multiple sessions. Closing a tab will result in the session being closed as well.                                             |
+| `useCompression`                | `boolean` | `true`            | Uses `WebWorkers` (if available) to compress the recording payload before uploading to Sentry.                                                                                                                                |
+| `captureOnlyOnError`            | `boolean` | `false`           | Only capture the recording when an error happens.                                                                                                                                                                             |
+| `recordingConfig.maskAllInputs` | `boolean` | `true`            | Mask all `<input>` elements                                                                                                                                                                                                   |
+| `recordingConfig.blockClass`    | `string`  | `'sentry-block'`  | Redact all elements with the class name `sentry-block`                                                                                                                                                                        |
+| `recordingConfig.ignoreClass`   | `string`  | `'sentry-ignore'` | Ignores all elements with the class name `sentry-ignore`                                                                                                                                                                      |
+| `recordingConfig.maskTextClass` | `string`  | `'sentry-mask'`   | Mask all elements with the class name `sentry-ignore`                                                                                                                                                                         |

--- a/demo/src/index.js
+++ b/demo/src/index.js
@@ -5,14 +5,14 @@ import App from './App';
 import * as serviceWorker from './serviceWorker';
 import * as Sentry from '@sentry/browser';
 
-import { SentryReplay } from '@sentry/replay';
+import { Replay } from '@sentry/replay';
 
 Sentry.init({
   // org/project: sentry-emerging-tech/replays
   dsn: 'https://8616b02314c14ca1b499b098e1991eb5@o1176005.ingest.sentry.io/6273278',
   environment: 'demo',
   tracesSampleRate: 1.0,
-  integrations: [new SentryReplay({ stickySession: true })],
+  integrations: [new Replay({ stickySession: true })],
 });
 
 ReactDOM.render(<App />, document.getElementById('root'));

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,4 +1,4 @@
-import { SentryReplay } from '@';
+import { Replay } from '@';
 import { Session } from '@/session/Session';
 
 // @ts-expect-error TS error, this is replaced in prod builds bc of rollup
@@ -10,7 +10,7 @@ const ENVELOPE_URL_REGEX = new RegExp(
 
 expect.extend({
   toHaveSameSession(
-    received: jest.Mocked<SentryReplay>,
+    received: jest.Mocked<Replay>,
     expected: undefined | Session
   ) {
     const pass = this.equals(received.session?.id, expected?.id) as boolean;
@@ -41,7 +41,7 @@ expect.extend({
    * Checks the last call to `sendReplayRequest` and ensures a replay was uploaded
    */
   toHaveSentReplay(
-    received: jest.Mocked<SentryReplay>,
+    received: jest.Mocked<Replay>,
     expected?: string | Uint8Array
   ) {
     const { calls } = received.sendReplayRequest.mock;

--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -5,7 +5,7 @@ import { captureException } from '@sentry/browser';
 import * as SentryCore from '@sentry/core';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { SentryReplay } from '@';
+import { Replay } from '@';
 import * as CaptureReplayEvent from '@/api/captureReplayEvent';
 import {
   SESSION_IDLE_DURATION,
@@ -19,8 +19,8 @@ async function advanceTimers(time: number) {
   await new Promise(process.nextTick);
 }
 
-describe('SentryReplay (capture only on error)', () => {
-  let replay: SentryReplay;
+describe('Replay (capture only on error)', () => {
+  let replay: Replay;
   type MockSendReplayRequest = jest.MockedFunction<
     typeof replay.sendReplayRequest
   >;

--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -2,7 +2,7 @@
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { SentryReplay } from '@';
+import { Replay } from '@';
 import {
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
@@ -15,8 +15,8 @@ async function advanceTimers(time: number) {
   await new Promise(process.nextTick);
 }
 
-describe('SentryReplay (no sticky)', () => {
-  let replay: SentryReplay;
+describe('Replay (no sticky)', () => {
+  let replay: Replay;
   type MockSendReplayRequest = jest.MockedFunction<
     typeof replay.sendReplayRequest
   >;

--- a/src/index-sampling.test.ts
+++ b/src/index-sampling.test.ts
@@ -5,7 +5,7 @@ import { mockRrweb, mockSdk } from '@test';
 
 jest.useFakeTimers({ advanceTimers: true });
 
-describe('SentryReplay (sampling)', () => {
+describe('Replay (sampling)', () => {
   it('does nothing if not sampled', async () => {
     const { record: mockRecord } = mockRrweb();
     const { replay } = mockSdk({

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,7 +3,7 @@ import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
 
-import { SentryReplay } from '@';
+import { Replay } from '@';
 import * as CaptureReplayEvent from '@/api/captureReplayEvent';
 import {
   REPLAY_SESSION_KEY,
@@ -18,8 +18,8 @@ async function advanceTimers(time: number) {
   await new Promise(process.nextTick);
 }
 
-describe('SentryReplay', () => {
-  let replay: SentryReplay;
+describe('Replay', () => {
+  let replay: Replay;
   const prevLocation = window.location;
 
   type MockSendReplayRequest = jest.MockedFunction<

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,10 +45,10 @@ import type {
   RecordedEvents,
   RecordingConfig,
   RecordingEvent,
+  ReplayConfiguration,
   ReplayEventContext,
+  ReplayPluginOptions,
   ReplayRequest,
-  SentryReplayConfiguration,
-  SentryReplayPluginOptions,
 } from './types';
 
 /**
@@ -60,7 +60,7 @@ const BASE_RETRY_INTERVAL = 5000;
 const MAX_RETRY_COUNT = 3;
 const UNABLE_TO_SEND_REPLAY = 'Unable to send Replay';
 
-export class SentryReplay implements Integration {
+export class Replay implements Integration {
   /**
    * @inheritDoc
    */
@@ -69,7 +69,7 @@ export class SentryReplay implements Integration {
   /**
    * @inheritDoc
    */
-  public name: string = SentryReplay.id;
+  public name: string = Replay.id;
 
   public eventBuffer: IEventBuffer | null;
 
@@ -83,7 +83,7 @@ export class SentryReplay implements Integration {
    */
   readonly recordingOptions: RecordingConfig;
 
-  readonly options: SentryReplayPluginOptions;
+  readonly options: ReplayPluginOptions;
 
   private performanceObserver: PerformanceObserver | null = null;
 
@@ -146,7 +146,7 @@ export class SentryReplay implements Integration {
       maskTextClass = 'sentry-mask',
       ...recordingOptions
     } = {},
-  }: SentryReplayConfiguration = {}) {
+  }: ReplayConfiguration = {}) {
     this.recordingOptions = {
       maskAllInputs,
       blockClass,

--- a/src/stop.test.ts
+++ b/src/stop.test.ts
@@ -2,13 +2,13 @@ import * as SentryUtils from '@sentry/utils';
 // mock functions need to be imported first
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { SentryReplay } from '@';
+import { Replay } from '@';
 import { SESSION_IDLE_DURATION } from '@/session/constants';
 
 jest.useFakeTimers({ advanceTimers: true });
 
-describe('SentryReplay - stop', () => {
-  let replay: SentryReplay;
+describe('Replay - stop', () => {
+  let replay: Replay;
   const prevLocation = window.location;
 
   type MockSendReplayRequest = jest.MockedFunction<

--- a/src/types.ts
+++ b/src/types.ts
@@ -50,7 +50,7 @@ export interface WorkerResponse {
   response: string | Uint8Array;
 }
 
-export interface SentryReplayPluginOptions {
+export interface ReplayPluginOptions {
   /**
    * The amount of time to wait before sending a replay
    */
@@ -94,7 +94,7 @@ export interface SentryReplayPluginOptions {
   maskAllText?: boolean;
 }
 
-export interface SentryReplayConfiguration extends SentryReplayPluginOptions {
+export interface ReplayConfiguration extends ReplayPluginOptions {
   /**
    * Options for `rrweb.record()`
    */

--- a/test/index.ts
+++ b/test/index.ts
@@ -1,4 +1,4 @@
-export * from './mocks/mockRrweb'; // XXX: Needs to happen before `mockSdk` or importing SentryReplay!
+export * from './mocks/mockRrweb'; // XXX: Needs to happen before `mockSdk` or importing Replay!
 export * from './mocks/mockSdk';
 
 export const BASE_TIMESTAMP = new Date('2020-02-02 00:00:00').getTime(); // 1580619600000

--- a/test/mocks/mockSdk.ts
+++ b/test/mocks/mockSdk.ts
@@ -3,11 +3,11 @@ jest.unmock('@sentry/browser');
 import { BrowserOptions, init } from '@sentry/browser';
 import { Transport } from '@sentry/types';
 
-import { SentryReplay } from '@';
-import { SentryReplayConfiguration } from '@/types';
+import { Replay } from '@';
+import { ReplayConfiguration } from '@/types';
 
 interface MockSdkParams {
-  replayOptions?: SentryReplayConfiguration;
+  replayOptions?: ReplayConfiguration;
   sentryOptions?: BrowserOptions;
 }
 
@@ -48,7 +48,7 @@ export function mockSdk({
     transport: () => new MockTransport(),
   },
 }: MockSdkParams = {}) {
-  const replay = new SentryReplay(replayOptions);
+  const replay = new Replay(replayOptions);
 
   init({ ...sentryOptions, integrations: [replay] });
   jest.spyOn(replay, 'sendReplayRequest');


### PR DESCRIPTION
This is a bit more consistent with other SDK integrations in `sentry-javascript` where they are not prefixed with `Sentry`
