### PR TITLE
fix: Remove typescript `paths` aliases

### DIFF
--- a/config/tsconfig.core.json
+++ b/config/tsconfig.core.json
@@ -7,11 +7,7 @@
     "baseUrl": "..",
     "rootDir": "..",
     "strictNullChecks": true,
-    "outDir": "dist",
-    "paths": {
-      "@": ["./src"],
-      "@/*": ["./src/*"]
-    }
+    "outDir": "dist"
   },
   "include": ["../src/**/*.ts"],
   "exclude": ["../src/**/*.test.ts"]

--- a/config/tsconfig.worker.json
+++ b/config/tsconfig.worker.json
@@ -4,11 +4,7 @@
     "declaration": false,
     "lib": ["webworker", "scripthost"],
     "baseUrl": "../worker/src",
-    "outDir": "../src/worker",
-    "paths": {
-      "@worker": ["../worker/src"],
-      "@worker/*": ["../worker/src/*"]
-    }
+    "outDir": "../src/worker"
   },
   "include": ["../worker/src/worker.ts", "../src/types.ts"]
 }

--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -1,5 +1,5 @@
-import { Replay } from '@';
-import { Session } from '@/session/Session';
+import { Session } from './src/session/Session';
+import { Replay } from './src';
 
 // @ts-expect-error TS error, this is replaced in prod builds bc of rollup
 global.__SENTRY_REPLAY_VERSION__ = 'version:Test';

--- a/src/api/captureReplayEvent.ts
+++ b/src/api/captureReplayEvent.ts
@@ -1,8 +1,8 @@
 import { captureEvent, withScope } from '@sentry/core';
 
-import { REPLAY_EVENT_NAME } from '@/session/constants';
-import { InitialState } from '@/types';
-import { addInternalBreadcrumb } from '@/util/addInternalBreadcrumb';
+import { REPLAY_EVENT_NAME } from '../session/constants';
+import { InitialState } from '../types';
+import { addInternalBreadcrumb } from '../util/addInternalBreadcrumb';
 
 export interface CaptureReplayEventParams {
   /**

--- a/src/coreHandlers/getBreadcrumbHandler.ts
+++ b/src/coreHandlers/getBreadcrumbHandler.ts
@@ -1,4 +1,4 @@
-import { InstrumentationTypeBreadcrumb } from '@/types';
+import { InstrumentationTypeBreadcrumb } from '../types';
 
 import { handleDom } from './handleDom';
 import { handleScope } from './handleScope';

--- a/src/coreHandlers/getSpanHandler.ts
+++ b/src/coreHandlers/getSpanHandler.ts
@@ -1,4 +1,4 @@
-import { InstrumentationTypeSpan } from '@/types';
+import { InstrumentationTypeSpan } from '../types';
 
 import { handleFetch } from './handleFetch';
 import { handleHistory } from './handleHistory';

--- a/src/coreHandlers/handleDom.ts
+++ b/src/coreHandlers/handleDom.ts
@@ -1,7 +1,7 @@
 import { htmlTreeAsString } from '@sentry/utils';
 import { record } from 'rrweb';
 
-import createBreadcrumb from '@/util/createBreadcrumb';
+import createBreadcrumb from '../util/createBreadcrumb';
 
 export function handleDom(handlerData: any) {
   // Taken from https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/integrations/breadcrumbs.ts#L112

--- a/src/coreHandlers/handleFetch.ts
+++ b/src/coreHandlers/handleFetch.ts
@@ -1,5 +1,5 @@
-import { ReplayPerformanceEntry } from '@/createPerformanceEntry';
-import { isIngestHost } from '@/util/isIngestHost';
+import { ReplayPerformanceEntry } from '../createPerformanceEntry';
+import { isIngestHost } from '../util/isIngestHost';
 
 interface FetchHandlerData {
   args: Parameters<typeof fetch>;

--- a/src/coreHandlers/handleHistory.ts
+++ b/src/coreHandlers/handleHistory.ts
@@ -1,4 +1,4 @@
-import { ReplayPerformanceEntry } from '@/createPerformanceEntry';
+import { ReplayPerformanceEntry } from '../createPerformanceEntry';
 
 interface HistoryHandlerData {
   from: string;

--- a/src/coreHandlers/handleScope.ts
+++ b/src/coreHandlers/handleScope.ts
@@ -1,6 +1,6 @@
 import { Breadcrumb, Scope } from '@sentry/types';
 
-import createBreadcrumb from '@/util/createBreadcrumb';
+import createBreadcrumb from '../util/createBreadcrumb';
 
 let _LAST_BREADCRUMB: null | Breadcrumb = null;
 

--- a/src/coreHandlers/handleXhr.ts
+++ b/src/coreHandlers/handleXhr.ts
@@ -1,5 +1,5 @@
-import { ReplayPerformanceEntry } from '@/createPerformanceEntry';
-import { isIngestHost } from '@/util/isIngestHost';
+import { ReplayPerformanceEntry } from '../createPerformanceEntry';
+import { isIngestHost } from '../util/isIngestHost';
 
 // From sentry-javascript
 // e.g. https://github.com/getsentry/sentry-javascript/blob/c7fc025bf9fa8c073fdb56351808ce53909fbe45/packages/utils/src/instrument.ts#L180

--- a/src/flush.test.ts
+++ b/src/flush.test.ts
@@ -2,8 +2,7 @@
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { SESSION_IDLE_DURATION } from '@/session/constants';
-
+import { SESSION_IDLE_DURATION } from './session/constants';
 import { createPerformanceEntries } from './createPerformanceEntry';
 
 jest.useFakeTimers({ advanceTimers: true });

--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -5,12 +5,12 @@ import { captureException } from '@sentry/browser';
 import * as SentryCore from '@sentry/core';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { Replay } from '@';
-import * as CaptureReplayEvent from '@/api/captureReplayEvent';
+import * as CaptureReplayEvent from './api/captureReplayEvent';
 import {
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
-} from '@/session/constants';
+} from './session/constants';
+import { Replay } from './';
 
 jest.useFakeTimers({ advanceTimers: true });
 

--- a/src/index-noSticky.test.ts
+++ b/src/index-noSticky.test.ts
@@ -2,11 +2,11 @@
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { Replay } from '@';
 import {
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
-} from '@/session/constants';
+} from './session/constants';
+import { Replay } from './';
 
 jest.useFakeTimers({ advanceTimers: true });
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -3,15 +3,14 @@ import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
 
-import { Replay } from '@';
-import * as CaptureReplayEvent from '@/api/captureReplayEvent';
+import * as CaptureReplayEvent from './api/captureReplayEvent';
 import {
   REPLAY_SESSION_KEY,
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
-} from '@/session/constants';
-
+} from './session/constants';
 import * as CaptureInternalException from './util/captureInternalException';
+import { Replay } from './';
 
 jest.useFakeTimers({ advanceTimers: true });
 

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -1,6 +1,6 @@
 import { uuid4 } from '@sentry/utils';
 
-import { isSampled } from '@/util/isSampled';
+import { isSampled } from '../util/isSampled';
 
 import { saveSession } from './saveSession';
 

--- a/src/session/createSession.ts
+++ b/src/session/createSession.ts
@@ -1,4 +1,4 @@
-import { logger } from '@/util/logger';
+import { logger } from '../util/logger';
 
 import { saveSession } from './saveSession';
 import { Session } from './Session';

--- a/src/session/getSession.ts
+++ b/src/session/getSession.ts
@@ -1,5 +1,5 @@
-import { isSessionExpired } from '@/util/isSessionExpired';
-import { logger } from '@/util/logger';
+import { isSessionExpired } from '../util/isSessionExpired';
+import { logger } from '../util/logger';
 
 import { createSession } from './createSession';
 import { fetchSession } from './fetchSession';

--- a/src/stop.test.ts
+++ b/src/stop.test.ts
@@ -2,8 +2,8 @@ import * as SentryUtils from '@sentry/utils';
 // mock functions need to be imported first
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { Replay } from '@';
-import { SESSION_IDLE_DURATION } from '@/session/constants';
+import { SESSION_IDLE_DURATION } from './session/constants';
+import { Replay } from './';
 
 jest.useFakeTimers({ advanceTimers: true });
 

--- a/src/util/createPayload.ts
+++ b/src/util/createPayload.ts
@@ -1,4 +1,4 @@
-import { RecordedEvents } from '@/types';
+import { RecordedEvents } from '../types';
 
 export function createPayload({
   events,

--- a/src/util/isSessionExpired.test.ts
+++ b/src/util/isSessionExpired.test.ts
@@ -1,4 +1,4 @@
-import { Session } from '@/session/Session';
+import { Session } from '../session/Session';
 
 import { isSessionExpired } from './isSessionExpired';
 

--- a/src/util/isSessionExpired.ts
+++ b/src/util/isSessionExpired.ts
@@ -1,4 +1,4 @@
-import { Session } from '@/session/Session';
+import { Session } from '../session/Session';
 
 import { isExpired } from './isExpired';
 

--- a/test/mocks/mockRrweb.ts
+++ b/test/mocks/mockRrweb.ts
@@ -1,4 +1,4 @@
-import { RecordingEvent } from '@/types';
+import { RecordingEvent } from '../../src/types';
 
 type RecordAdditionalProperties = {
   takeFullSnapshot: jest.Mock;

--- a/test/mocks/mockSdk.ts
+++ b/test/mocks/mockSdk.ts
@@ -3,8 +3,8 @@ jest.unmock('@sentry/browser');
 import { BrowserOptions, init } from '@sentry/browser';
 import { Transport } from '@sentry/types';
 
-import { Replay } from '@';
-import { ReplayConfiguration } from '@/types';
+import { Replay } from '../../src';
+import { ReplayConfiguration } from '../../src/types';
 
 interface MockSdkParams {
   replayOptions?: ReplayConfiguration;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,8 +2,6 @@
   "extends": "./config/tsconfig.core.json",
   "compilerOptions": {
     "paths": {
-      "@": ["./src"],
-      "@/*": ["./src/*"],
       "@test": ["./test"],
       "@test/*": ["./test/*"]
     }


### PR DESCRIPTION
We were using the tsc config `paths` for import aliases, *but* tsc does not rewrite paths. This needs to be handled in a build tool, in our case we could use a plugin like this https://www.npmjs.com/package/@rollup/plugin-alias. However, we are going to just remove the usage of import aliases altogether as there was mixed usage of it and I am opting to keep things a bit simpler for now.
