### PR TITLE
fix: Prevent starting up if window is not defined

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -60,6 +60,8 @@ const MEDIA_SELECTORS =
 
 let _initialized = false;
 
+const isBrowser = typeof window !== 'undefined';
+
 export class Replay implements Integration {
   /**
    * @inheritDoc
@@ -217,6 +219,9 @@ export class Replay implements Integration {
    * other global event processors to finish
    */
   setupOnce() {
+    if (!isBrowser) {
+      return;
+    }
     // XXX: See method comments above
     window.setTimeout(() => this.start());
   }
@@ -227,6 +232,10 @@ export class Replay implements Integration {
    * Creates or loads a session, attaches listeners to varying events (DOM, PerformanceObserver, Recording, Sentry SDK, etc)
    */
   start() {
+    if (!isBrowser) {
+      return;
+    }
+
     this.loadSession({ expiry: SESSION_IDLE_DURATION });
 
     // If there is no session, then something bad has happened - can't continue
@@ -295,6 +304,9 @@ export class Replay implements Integration {
    * Currently, this needs to be manually called (e.g. for tests). Sentry SDK does not support a teardown
    */
   stop() {
+    if (!isBrowser) {
+      return;
+    }
     logger.log('Stopping Replays');
     this.isEnabled = false;
     this.removeListeners();


### PR DESCRIPTION
Test notes:

I setup replays on my gatsby test app and was able to recreate the issue:

The config:
```typescript
#gatsby-config.ts

const config: GatsbyConfig = {
  ...
  plugins: [
    {
      resolve: "@sentry/gatsby",
    },
  ],
};
export default config;
```

```typescript
#sentry.config.ts

import * as Sentry from '@sentry/gatsby';
import { Replay } from "@sentry/replay";

Sentry.init({
  dsn: "https://c214503190724086b0b4017d8fe5d65a@o1176005.ingest.sentry.io/6622945",
  sampleRate: 1.0, // Adjust this value in production
  integrations: [
    new Replay(),
  ],
});
```

The failing output:
```bash
There was an error compiling the html.js component for the development server.
See our docs page on debugging HTML builds for help https://gatsby.dev/debug-html ReferenceError: window is not defined


  1226 |         var _this = this;
  1227 |         // XXX: See method comments above
> 1228 |         window.setTimeout(function () { return _this.start(); });
       |         ^
  1229 |     };
  1230 |     /**
  1231 |      * Initializes the plugin.


  WebpackError: ReferenceError: window is not defined
```

After the fix we're able to build and run the app, and record replays:
| Test App | Replay |
| --- | --- |
| <img width="1156" alt="Screen Shot 2022-10-18 at 5 38 11 PM" src="https://user-images.githubusercontent.com/187460/196570601-daf68ea5-25e4-4804-9365-9dab03ddf3a1.png"> | <img width="438" alt="Screen Shot 2022-10-18 at 5 37 09 PM" src="https://user-images.githubusercontent.com/187460/196570323-85e7d204-b445-4457-aa2b-8af8ea613688.png"> |

In a gatsby app, or most of these other frameworks, it is possible to do have a node-only or browser-only config. With Gatsby, for example, I would remove `new Replay()` from `sentry.config.ts` and instead add `gatsby-browser.tsx` with this content to manually start the replay session (that's not better though, but it is a work around):
```typescript
const { Replay } = require("@sentry/replay");

exports.wrapRootElement = ({ element, props }) => {
  const replay = new Replay({
    blockAllMedia: false,
    maskAllText: false,
  });
  replay.start();

  return element;
};
```

Fixes #246

