### PR TITLE
ci: Update deprecated `set-output` call

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
 
       - id: versions
         run: |
-          echo "::set-output name=node::$(jq -r '.volta.node' package.json)"
+          echo "echo node=$(jq -r '.volta.node' package.json)" >> $GITHUB_OUTPUT
 
       - uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/
