### PR TITLE
bug: Prevent calling isInternal when not in the browser

### DIFF
--- a/src/util/isInternal.ts
+++ b/src/util/isInternal.ts
@@ -1,7 +1,12 @@
+const isBrowser = typeof window !== 'undefined';
+
 /**
  * Returns true if we are currently recording an internal to Sentry replay
  * (e.g. on https://sentry.io )
  */
 export function isInternal() {
-  return ['sentry.io', 'dev.getsentry.net'].includes(window.location.host);
+  return (
+    isBrowser &&
+    ['sentry.io', 'dev.getsentry.net'].includes(window.location.host)
+  );
 }


### PR DESCRIPTION
The only method that could really be called a) in a node env b) during setup is `captureInternalException` which calls down to `isInternal`.
So we need to make sure that `isInternal` is only accessing the `window` object if it exists.

`lodash.debounce`  is also called, but that's isomorphic. 