### PR TITLE
feat: Stop recording when user is idle

### DIFF
--- a/src/coreHandlers/handleDom.ts
+++ b/src/coreHandlers/handleDom.ts
@@ -1,7 +1,7 @@
 import { htmlTreeAsString } from '@sentry/utils';
 import { record } from 'rrweb';
 
-import createBreadcrumb from '../util/createBreadcrumb';
+import { createBreadcrumb } from '../util/createBreadcrumb';
 
 export function handleDom(handlerData: any) {
   // Taken from https://github.com/getsentry/sentry-javascript/blob/master/packages/browser/src/integrations/breadcrumbs.ts#L112

--- a/src/coreHandlers/handleScope.ts
+++ b/src/coreHandlers/handleScope.ts
@@ -1,6 +1,6 @@
 import { Breadcrumb, Scope } from '@sentry/types';
 
-import createBreadcrumb from '../util/createBreadcrumb';
+import { createBreadcrumb } from '../util/createBreadcrumb';
 
 let _LAST_BREADCRUMB: null | Breadcrumb = null;
 

--- a/src/index-captureOnlyOnError.test.ts
+++ b/src/index-captureOnlyOnError.test.ts
@@ -43,6 +43,7 @@ describe('Replay (capture only on error)', () => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     // mockSendReplayRequest.mockClear();
     mockRecord.takeFullSnapshot.mockClear();
+    jest.clearAllMocks();
   });
 
   afterEach(async () => {
@@ -59,7 +60,7 @@ describe('Replay (capture only on error)', () => {
   });
 
   it('uploads a replay when captureException is called', async () => {
-    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
     mockRecord._emitter(TEST_EVENT);
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
@@ -71,7 +72,12 @@ describe('Replay (capture only on error)', () => {
     await new Promise(process.nextTick);
     await new Promise(process.nextTick);
 
-    expect(replay).toHaveSentReplay({ events: JSON.stringify([TEST_EVENT]) });
+    expect(replay).toHaveSentReplay({
+      events: JSON.stringify([
+        { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 },
+        TEST_EVENT,
+      ]),
+    });
   });
 
   it('does not send a replay when triggering a full dom snapshot when document becomes visible after [VISIBILITY_CHANGE_TIMEOUT]ms', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,7 +287,9 @@ export class Replay implements Integration {
   }
 
   /**
-   * Start recording. Note that this will cause a new DOM checkout
+   * Start recording.
+   *
+   * Note that this will cause a new DOM checkout
    */
   startRecording() {
     this.stopRecording = record({
@@ -323,6 +325,12 @@ export class Replay implements Integration {
     }
   }
 
+  /**
+   * Resumes recording, see notes for `pause().
+   *
+   * Note that calling `startRecording()` here will cause a
+   * new DOM checkout.`
+   */
   resume() {
     this.isPaused = false;
     this.startRecording();
@@ -846,7 +854,7 @@ export class Replay implements Integration {
       // Create a new session, otherwise when the user action is flushed, it will get rejected due to an expired session.
       this.loadSession({ expiry: SESSION_IDLE_DURATION });
 
-      // Note: This will cause a new checkout
+      // Note: This will cause a new DOM checkout
       this.resume();
       return;
     }

--- a/src/session/getSession.ts
+++ b/src/session/getSession.ts
@@ -40,8 +40,9 @@ export function getSession({
   const session = currentSession || (stickySession && fetchSession());
 
   if (session) {
-    // If there is a session, check if it is valid (e.g. "last activity" time should be within the "session idle time")
-    // TODO: We should probably set a max age on this as well
+    // If there is a session, check if it is valid (e.g. "last activity" time
+    // should be within the "session idle time", and "session started" time is
+    // within "max session time").
     const isExpired = isSessionExpired(session, expiry);
 
     if (!isExpired) {

--- a/src/stop.test.ts
+++ b/src/stop.test.ts
@@ -43,6 +43,7 @@ describe('Replay - stop', () => {
   beforeEach(() => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     replay.eventBuffer?.destroy();
+    jest.clearAllMocks();
   });
 
   afterEach(async () => {
@@ -76,7 +77,7 @@ describe('Replay - stop', () => {
     const ELAPSED = 5000;
     // Not sure where the 20ms comes from tbh
     const EXTRA_TICKS = 20;
-    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 2 };
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
 
     // stop replays
     replay.stop();
@@ -122,7 +123,16 @@ describe('Replay - stop', () => {
     await new Promise(process.nextTick);
     expect(replay.sendReplayRequest).toHaveBeenCalled();
     expect(replay).toHaveSentReplay({
-      events: JSON.stringify([TEST_EVENT, hiddenBreadcrumb]),
+      events: JSON.stringify([
+        // This event happens when we call `replay.start`
+        {
+          data: { isCheckout: true },
+          timestamp: BASE_TIMESTAMP + ELAPSED + EXTRA_TICKS,
+          type: 2,
+        },
+        TEST_EVENT,
+        hiddenBreadcrumb,
+      ]),
     });
     // Session's last activity is last updated when we call `setup()` and *NOT*
     // when tab is blurred

--- a/src/util/createBreadcrumb.ts
+++ b/src/util/createBreadcrumb.ts
@@ -2,7 +2,7 @@ import type { Breadcrumb } from '@sentry/types';
 
 type RequiredProperties = 'category' | 'message';
 
-export default function createBreadcrumb(
+export function createBreadcrumb(
   breadcrumb: Pick<Breadcrumb, RequiredProperties> &
     Partial<Omit<Breadcrumb, RequiredProperties>>
 ): Breadcrumb {

--- a/test/mocks/mockRrweb.ts
+++ b/test/mocks/mockRrweb.ts
@@ -22,6 +22,10 @@ jest.mock('rrweb', () => {
   const mockRecordFn: jest.Mock & Partial<RecordAdditionalProperties> = jest.fn(
     ({ emit }) => {
       mockRecordFn._emitter = emit;
+
+      return function stop() {
+        mockRecordFn._emitter = jest.fn();
+      };
     }
   );
   mockRecordFn.takeFullSnapshot = jest.fn((isCheckout) => {

--- a/test/mocks/mockRrweb.ts
+++ b/test/mocks/mockRrweb.ts
@@ -17,30 +17,32 @@ type RecordAdditionalProperties = {
 export type RecordMock = jest.MockedFunction<typeof rrweb.record> &
   RecordAdditionalProperties;
 
+function createCheckoutPayload(isCheckout = true) {
+  return {
+    data: { isCheckout },
+    timestamp: new Date().getTime(),
+    type: isCheckout ? 2 : 3,
+  };
+}
+
 jest.mock('rrweb', () => {
   const ActualRrweb = jest.requireActual('rrweb');
   const mockRecordFn: jest.Mock & Partial<RecordAdditionalProperties> = jest.fn(
     ({ emit }) => {
       mockRecordFn._emitter = emit;
 
+      emit(createCheckoutPayload());
       return function stop() {
         mockRecordFn._emitter = jest.fn();
       };
     }
   );
-  mockRecordFn.takeFullSnapshot = jest.fn((isCheckout) => {
+  mockRecordFn.takeFullSnapshot = jest.fn((isCheckout: boolean) => {
     if (!mockRecordFn._emitter) {
       return;
     }
 
-    mockRecordFn._emitter(
-      {
-        data: { isCheckout },
-        timestamp: new Date().getTime(),
-        type: isCheckout ? 2 : 3,
-      },
-      isCheckout
-    );
+    mockRecordFn._emitter(createCheckoutPayload(isCheckout), isCheckout);
   });
 
   return {


### PR DESCRIPTION
If a user has not performed any user activity for MAX_SESSION_LIFE (30 minutes currently), stop dom recording until a user performs an action (currently: mouse click, navigation, tab focus).

Previously, dom recording would trigger new sessions indefinitely.

Fixes #204 
