### PR TITLE
fix: Treat sessions with `segmentId:0` as new session

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -98,13 +98,6 @@ export class Replay implements Integration {
   private retryInterval = BASE_RETRY_INTERVAL;
 
   private debouncedFlush: ReturnType<typeof debounce>;
-
-  /**
-   * Flag when a new session has been created. Captured replay events behave
-   * slightly differently in this case: `replay_start_timestamp` is included.
-   */
-  private newSessionCreated = false;
-
   private flushLock: Promise<unknown> | null = null;
 
   /**
@@ -356,7 +349,6 @@ export class Replay implements Integration {
     // If session was newly created (i.e. was not loaded from storage), then
     // enable flag to create the root replay
     if (type === 'new') {
-      this.newSessionCreated = true;
       this.setInitialState();
     }
 
@@ -815,7 +807,7 @@ export class Replay implements Integration {
     // Only record earliest event if a new session was created, otherwise it
     // shouldn't be relevant
     if (
-      (this.newSessionCreated || this.session?.segmentId === 0) &&
+      this.session?.segmentId === 0 &&
       (!this.context.earliestEvent ||
         timestampInMs < this.context.earliestEvent)
     ) {
@@ -1050,7 +1042,6 @@ export class Replay implements Integration {
     // NOTE: Copy values from instance members, as it's possible they could
     // change before the flush finishes.
     const replayId = this.session.id;
-    const newSessionCreated = this.newSessionCreated;
     // Always increment segmentId regardless of outcome of sending replay
     const segmentId = this.session.segmentId++;
 
@@ -1061,9 +1052,8 @@ export class Replay implements Integration {
         replayId,
         events: recordingData,
         segmentId,
-        includeReplayStartTimestamp: newSessionCreated || segmentId === 0,
+        includeReplayStartTimestamp: segmentId === 0,
       });
-      this.newSessionCreated = false;
     } catch (err) {
       captureInternalException(err);
       console.error(err);

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,16 +358,6 @@ export class Replay implements Integration {
     if (type === 'new') {
       this.newSessionCreated = true;
       this.setInitialState();
-    } else {
-      // NOTE: This shouldn't happen
-      if (session.segmentId === 0) {
-        addInternalBreadcrumb({
-          message: `previous session: ${
-            this.session ? this.session.toJSON() : 'null'
-          }
-current session: ${session.toJSON()}`,
-        });
-      }
     }
 
     if (session.id !== this.session?.id) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -358,6 +358,16 @@ export class Replay implements Integration {
     if (type === 'new') {
       this.newSessionCreated = true;
       this.setInitialState();
+    } else {
+      // NOTE: This shouldn't happen
+      if (session.segmentId === 0) {
+        addInternalBreadcrumb({
+          message: `previous session: ${
+            this.session ? this.session.toJSON() : 'null'
+          }
+current session: ${session.toJSON()}`,
+        });
+      }
     }
 
     if (session.id !== this.session?.id) {
@@ -815,7 +825,7 @@ export class Replay implements Integration {
     // Only record earliest event if a new session was created, otherwise it
     // shouldn't be relevant
     if (
-      this.newSessionCreated &&
+      (this.newSessionCreated || this.session?.segmentId === 0) &&
       (!this.context.earliestEvent ||
         timestampInMs < this.context.earliestEvent)
     ) {
@@ -1061,7 +1071,7 @@ export class Replay implements Integration {
         replayId,
         events: recordingData,
         segmentId,
-        includeReplayStartTimestamp: newSessionCreated,
+        includeReplayStartTimestamp: newSessionCreated || segmentId === 0,
       });
       this.newSessionCreated = false;
     } catch (err) {

--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -20,16 +20,16 @@ export function fetchSession(): Session | null {
     return null;
   }
 
-  const sessionObj = JSON.parse(sessionStringFromStorage);
-
-  // NOTE: This shouldn't happen
-  if (sessionObj.segmentId === 0) {
-    captureInternalException(
-      new Error('Session storage object with segmentId = 0')
-    );
-  }
-
   try {
+    const sessionObj = JSON.parse(sessionStringFromStorage);
+
+    // NOTE: This shouldn't happen
+    if (sessionObj.segmentId === 0) {
+      captureInternalException(
+        new Error('Session storage object with segmentId = 0')
+      );
+    }
+
     return new Session(
       sessionObj,
       // We are assuming that if there is a saved item, then the session is sticky,

--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -1,3 +1,5 @@
+import { captureInternalException } from '../util/captureInternalException';
+
 import { REPLAY_SESSION_KEY } from './constants';
 import { Session } from './Session';
 
@@ -11,10 +13,25 @@ export function fetchSession(): Session | null {
     return null;
   }
 
+  const sessionStringFromStorage =
+    window.sessionStorage.getItem(REPLAY_SESSION_KEY);
+
+  if (!sessionStringFromStorage) {
+    return null;
+  }
+
+  const sessionObj = JSON.parse(sessionStringFromStorage);
+
+  // NOTE: This shouldn't happen
+  if (sessionObj.segmentId === 0) {
+    captureInternalException(
+      new Error('Session storage object with segmentId = 0')
+    );
+  }
+
   try {
     return new Session(
-      // @ts-expect-error: Type 'null' is not assignable to type 'string'.ts(2345)
-      JSON.parse(window.sessionStorage.getItem(REPLAY_SESSION_KEY)),
+      sessionObj,
       // We are assuming that if there is a saved item, then the session is sticky,
       // however this could break down if we used a different storage mechanism (e.g. localstorage)
       { stickySession: true }


### PR DESCRIPTION
We have lots of replays that are missing `replay_start_timestamp` on segment 0. For some reason, some sessions with `segmentId:0` are not being considered a "new" session. ~Ideally we would fix this but for now~, add some debug logging and forcefully treat session as "new" if after loading a session, it still has `segmentId:0`.

I've gone ahead and removed the new session flag, as it's not needed, instead we can assume that segment 0 requires the start timestamp.

Fixes https://github.com/getsentry/sentry/issues/40984