### PR TITLE
fix: `errorSampleRate` logic when `sessionSampleRate` < 1.0

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -198,17 +198,6 @@ export class Replay implements Integration {
       blockAllMedia,
     };
 
-    // Modify recording options to checkoutEveryNthSecond if this is defined, as we
-    // don't know when an error will occur, so we need to keep a buffer of replay events.
-    if (
-      this.options.errorSampleRate > 0 &&
-      this.options.sessionSampleRate < 1.0
-    ) {
-      // Checkout every minute, meaning we only get up-to one minute of events before the error happens
-      this.recordingOptions.checkoutEveryNms = 60000;
-      this.waitForError = true;
-    }
-
     // TODO(deprecated): Maintain backwards compatibility for alpha users
     if (usingDeprecatedCaptureOnlyOnError) {
       console.warn(
@@ -293,6 +282,16 @@ export class Replay implements Integration {
     if (!this.session.sampled) {
       // If session was not sampled, then we do not initialize the integration at all.
       return;
+    }
+
+    // Modify recording options to checkoutEveryNthSecond if
+    // sampling for error replay. This is because we don't know
+    // when an error will occur, so we need to keep a buffer of
+    // replay events.
+    if (this.session.sampled === 'error') {
+      // Checkout every minute, meaning we only get up-to one minute of events before the error happens
+      this.recordingOptions.checkoutEveryNms = 60000;
+      this.waitForError = true;
     }
 
     // setup() is generally called on page load or manually - in both cases we

--- a/src/session/Session.test.ts
+++ b/src/session/Session.test.ts
@@ -64,6 +64,26 @@ it('sticky Session saves to local storage', function () {
   expect(newSession.segmentId).toBe(1);
 });
 
+it('does not sample', function () {
+  const newSession = new Session(undefined, {
+    stickySession: true,
+    sessionSampleRate: 0.0,
+    errorSampleRate: 0.0,
+  });
+
+  expect(newSession.sampled).toBe(false);
+});
+
+it('samples using `sessionSampleRate`', function () {
+  const newSession = new Session(undefined, {
+    stickySession: true,
+    sessionSampleRate: 1.0,
+    errorSampleRate: 0.0,
+  });
+
+  expect(newSession.sampled).toBe('session');
+});
+
 it('samples using `errorSampleRate`', function () {
   const newSession = new Session(undefined, {
     stickySession: true,
@@ -71,13 +91,13 @@ it('samples using `errorSampleRate`', function () {
     errorSampleRate: 1.0,
   });
 
-  expect(newSession.sampled).toBe(true);
+  expect(newSession.sampled).toBe('error');
 });
 
 it('does not run sampling function if existing session was sampled', function () {
   const newSession = new Session(
     {
-      sampled: true,
+      sampled: 'session',
     },
     {
       stickySession: true,
@@ -86,5 +106,5 @@ it('does not run sampling function if existing session was sampled', function ()
     }
   );
 
-  expect(newSession.sampled).toBe(true);
+  expect(newSession.sampled).toBe('session');
 });

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -7,6 +7,8 @@ import { saveSession } from './saveSession';
 
 type StickyOption = Required<Pick<SessionOptions, 'stickySession'>>;
 
+type Sampled = false | 'session' | 'error';
+
 interface SessionObject {
   id: string;
 
@@ -26,9 +28,9 @@ interface SessionObject {
   segmentId: number;
 
   /**
-   * Is the session sampled?
+   * Is the session sampled? `null` if the sampled, otherwise, `session` or `error`
    */
-  sampled: boolean;
+  sampled: Sampled;
 }
 
 export class Session {
@@ -60,7 +62,7 @@ export class Session {
   /**
    * Is the Session sampled?
    */
-  private _sampled: boolean;
+  private _sampled: Sampled;
 
   public readonly options: StickyOption;
 
@@ -79,7 +81,11 @@ export class Session {
     this._segmentId = session.segmentId ?? 0;
     this._sampled =
       session.sampled ??
-      (isSampled(sessionSampleRate) || isSampled(errorSampleRate));
+      (isSampled(sessionSampleRate)
+        ? 'session'
+        : isSampled(errorSampleRate)
+        ? 'error'
+        : false);
 
     this.options = {
       stickySession,
@@ -128,7 +134,7 @@ export class Session {
     return this._sampled;
   }
 
-  set sampled(_isSampled: boolean) {
+  set sampled(_isSampled: Sampled) {
     throw new Error('Unable to change sampled value');
   }
 

--- a/src/session/getSession.test.ts
+++ b/src/session/getSession.test.ts
@@ -25,7 +25,7 @@ function createMockSession(when: number = new Date().getTime()) {
       segmentId: 0,
       lastActivity: when,
       started: when,
-      sampled: true,
+      sampled: 'session',
     },
     { stickySession: false, ...SAMPLE_RATES }
   );
@@ -65,7 +65,7 @@ it('creates a non-sticky session when one does not exist', function () {
     id: 'test_session_id',
     segmentId: 0,
     lastActivity: expect.any(Number),
-    sampled: true,
+    sampled: 'session',
     started: expect.any(Number),
   });
 
@@ -128,7 +128,7 @@ it('creates a sticky session when one does not exist', function () {
     id: 'test_session_id',
     segmentId: 0,
     lastActivity: expect.any(Number),
-    sampled: true,
+    sampled: 'session',
     started: expect.any(Number),
   });
 
@@ -137,7 +137,7 @@ it('creates a sticky session when one does not exist', function () {
     id: 'test_session_id',
     segmentId: 0,
     lastActivity: expect.any(Number),
-    sampled: true,
+    sampled: 'session',
     started: expect.any(Number),
   });
 });
@@ -160,7 +160,7 @@ it('fetches an existing sticky session', function () {
     id: 'test_session_id',
     segmentId: 0,
     lastActivity: now,
-    sampled: true,
+    sampled: 'session',
     started: now,
   });
 });

--- a/src/session/saveSession.test.ts
+++ b/src/session/saveSession.test.ts
@@ -19,7 +19,7 @@ it('saves a valid session', function () {
       segmentId: 0,
       started: 1648827162630,
       lastActivity: 1648827162658,
-      sampled: true,
+      sampled: 'session',
     },
     { stickySession: true, sessionSampleRate: 1.0, errorSampleRate: 0 }
   );


### PR DESCRIPTION
Follow-up to: https://github.com/getsentry/sentry-replay/pull/268#discussion_r1013252541

`waitForError` state flag was being applied too early. We also need to be able to differentiate between the different types of sample (session vs error).
