### PR TITLE
feat: For error replays, reset state on checkout 

### DIFF
--- a/src/index-errorSampleRate.test.ts
+++ b/src/index-errorSampleRate.test.ts
@@ -13,6 +13,7 @@ import {
 import { captureException } from '@sentry/browser';
 import type { RecordMock } from '@test';
 import { BASE_TIMESTAMP } from '@test';
+import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
 
 import {
   REPLAY_SESSION_KEY,
@@ -407,6 +408,52 @@ describe('Replay (errorSampleRate)', () => {
         {
           data: { isCheckout: true },
           timestamp: BASE_TIMESTAMP + 10000 + 20,
+          type: 2,
+        },
+      ]),
+    });
+  });
+
+  it('has correct timestamps when error occurs much later than initial pageload/checkout', async () => {
+    const ELAPSED = 60000;
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    mockRecord._emitter(TEST_EVENT);
+
+    // add a mock performance event
+    replay.performanceEvents.push(PerformanceEntryResource());
+
+    jest.runAllTimers();
+    await new Promise(process.nextTick);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay).not.toHaveSentReplay();
+
+    jest.advanceTimersByTime(ELAPSED);
+
+    // in production, this happens at a time interval
+    // session started time should be updated to this current timestamp
+    mockRecord.takeFullSnapshot(true);
+
+    jest.runAllTimers();
+    await new Promise(process.nextTick);
+
+    captureException(new Error('testing'));
+
+    jest.runAllTimers();
+    await new Promise(process.nextTick);
+
+    expect(replay.session?.started).toBe(BASE_TIMESTAMP + ELAPSED + 20);
+
+    // Does not capture mouse click
+    expect(replay).toHaveSentReplay({
+      replayEventPayload: expect.objectContaining({
+        // Make sure the old performance event is thrown out
+        replay_start_timestamp: (BASE_TIMESTAMP + ELAPSED + 20) / 1000,
+      }),
+      events: JSON.stringify([
+        {
+          data: { isCheckout: true },
+          timestamp: BASE_TIMESTAMP + ELAPSED + 20,
           type: 2,
         },
       ]),

--- a/src/index-errorSampleRate.test.ts
+++ b/src/index-errorSampleRate.test.ts
@@ -43,7 +43,7 @@ async function getMockReplay(options: ReplayConfiguration = {}) {
   return replay;
 }
 
-describe('Replay (capture only on error)', () => {
+describe('Replay (errorSampleRate)', () => {
   let replay: Replay;
   let mockRecord: RecordMock;
   let domHandler: (args: any) => any;

--- a/src/index.ts
+++ b/src/index.ts
@@ -603,7 +603,7 @@ export class Replay implements Integration {
       // The session is always started immediately on pageload/init, but for
       // error-only replays, it should reflect the most recent checkout
       // when an error occurs. Clear any state that happens before this current
-      // checkout. This needs to happen before `addEvent()` that updates state
+      // checkout. This needs to happen before `addEvent()` which updates state
       // dependent on this reset.
       if (this.waitForError && event.type === 2) {
         this.setInitialState();

--- a/src/index.ts
+++ b/src/index.ts
@@ -566,6 +566,10 @@ export class Replay implements Integration {
       event.message !== UNABLE_TO_SEND_REPLAY // ignore this error because otherwise we could loop indefinitely with trying to capture replay and failing
     ) {
       setTimeout(async () => {
+        // Allow flush to complete before resuming as a session recording, otherwise
+        // the checkout from `startRecording` may be included in the payload.
+        // Prefer to keep the error replay as a separate (and smaller) segment
+        // than the session replay.
         await this.flushImmediate();
 
         if (this.stopRecording) {
@@ -614,6 +618,15 @@ export class Replay implements Integration {
       // be captured if they perform any follow-up actions.
       if (this.session?.previousSessionId) {
         return true;
+      }
+
+      // The session is always started immediately on pageload/init, but for
+      // error-only replays, it should be started with the most recent checkout
+      // when an error occurs. Update the session start timestamp to reflect
+      // this. Otherwise there could be lots of empty time between pageload and
+      // when an error occurs.
+      if (this.waitForError && this.session && this.context.earliestEvent) {
+        this.session.started = this.context.earliestEvent;
       }
 
       // If the full snapshot is due to an initial load, we will not have

--- a/src/index.ts
+++ b/src/index.ts
@@ -600,6 +600,15 @@ export class Replay implements Integration {
     }
 
     this.addUpdate(() => {
+      // The session is always started immediately on pageload/init, but for
+      // error-only replays, it should reflect the most recent checkout
+      // when an error occurs. Clear any state that happens before this current
+      // checkout. This needs to happen before `addEvent()` that updates state
+      // dependent on this reset.
+      if (this.waitForError && event.type === 2) {
+        this.setInitialState();
+      }
+
       // We need to clear existing events on a checkout, otherwise they are
       // incremental event updates and should be appended
       this.addEvent(event, isCheckout);
@@ -620,11 +629,8 @@ export class Replay implements Integration {
         return true;
       }
 
-      // The session is always started immediately on pageload/init, but for
-      // error-only replays, it should be started with the most recent checkout
-      // when an error occurs. Update the session start timestamp to reflect
-      // this. Otherwise there could be lots of empty time between pageload and
-      // when an error occurs.
+      // See note above re: session start needs to reflect the most recent
+      // checkout.
       if (this.waitForError && this.session && this.context.earliestEvent) {
         this.session.started = this.context.earliestEvent;
       }

--- a/src/session/Session.ts
+++ b/src/session/Session.ts
@@ -100,6 +100,13 @@ export class Session {
     return this._started;
   }
 
+  set started(newDate: number) {
+    this._started = newDate;
+    if (this.options.stickySession) {
+      saveSession(this);
+    }
+  }
+
   get lastActivity() {
     return this._lastActivity;
   }


### PR DESCRIPTION
Follow-up to https://github.com/getsentry/sentry-replay/pull/268#discussion_r1013504603

The session is always started immediately on pageload/init, but for
error-only replays, it should reflect the most recent checkout
when an error occurs.

Checkouts happen on an interval so, clear any state that happens before the current
checkout and update the session started time on every checkout.