### PR TITLE
fix: Remove "Session storage object with segmentId = 0" logging

### DIFF
--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -1,5 +1,4 @@
 import { SampleRates } from '../types';
-import { captureInternalException } from '../util/captureInternalException';
 
 import { REPLAY_SESSION_KEY } from './constants';
 import { Session } from './Session';
@@ -27,12 +26,7 @@ export function fetchSession({
   try {
     const sessionObj = JSON.parse(sessionStringFromStorage);
 
-    // NOTE: This shouldn't happen
-    if (sessionObj.segmentId === 0) {
-      captureInternalException(
-        new Error('Session storage object with segmentId = 0')
-      );
-    }
+    // TODO: It's unexpected, but people seem to encounter `sessionObj.segmentId === 0`
 
     return new Session(
       sessionObj,


### PR DESCRIPTION
We are seeing a big spike in this logged error: 
JAVASCRIPT-2AED

It's unexpected, but not blocking, so for now we're going to remove the alerting.