### PR TITLE
 feat: Fix initialState for error sessions 

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@sentry/replay",
-  "version": "0.6.11",
+  "version": "0.6.12-0",
   "description": "User replays for Sentry",
   "main": "dist/index.js",
   "module": "dist/index.es.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -271,6 +271,8 @@ export class Replay implements Integration {
       return;
     }
 
+    this.setInitialState();
+
     this.loadSession({ expiry: SESSION_IDLE_DURATION });
 
     // If there is no session, then something bad has happened - can't continue
@@ -303,10 +305,6 @@ export class Replay implements Integration {
     });
 
     this.addListeners();
-
-    // Tag all (non replay) events that get sent to Sentry with the current
-    // replay ID so that we can reference them later in the UI
-    addGlobalEventProcessor(this.handleGlobalEvent);
 
     this.startRecording();
 
@@ -438,6 +436,10 @@ export class Replay implements Integration {
         'history',
         this.handleCoreSpanListener('history')
       );
+
+      // Tag all (non replay) events that get sent to Sentry with the current
+      // replay ID so that we can reference them later in the UI
+      addGlobalEventProcessor(this.handleGlobalEvent);
 
       this.hasInitializedCoreListeners = true;
     }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1310,7 +1310,7 @@ export class Replay implements Integration {
       setContext('Replays', {
         retryCount: this.retryCount,
       });
-      captureInternalException(new Error(UNABLE_TO_SEND_REPLAY));
+      captureInternalException(ex);
 
       // If an error happened here, it's likely that uploading the attachment
       // failed, we'll can retry with the same events payload

--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -26,8 +26,6 @@ export function fetchSession({
   try {
     const sessionObj = JSON.parse(sessionStringFromStorage);
 
-    // TODO: It's unexpected, but people seem to encounter `sessionObj.segmentId === 0`
-
     return new Session(
       sessionObj,
       // We are assuming that if there is a saved item, then the session is sticky,


### PR DESCRIPTION
There was an incorrect assumption that loading from session storage implied that the session was new. We were only initializing initialState in this "new" case, instead we should initialize whenever `start()` is called.

Also fixes a bug where exceptions were being obscured because we were always capturing a new/created error instead of capturing the error that was thrown.