### PR TITLE
fix: Prevent `undefined` from becoming serialized in the segment payload

### DIFF
--- a/worker/src/Compressor.ts
+++ b/worker/src/Compressor.ts
@@ -22,10 +22,13 @@ export class Compressor {
     // Fake an array by adding a `[`
     this.deflate.push('[', constants.Z_NO_FLUSH);
 
-    return true;
+    return;
   }
 
   addEvent(data: Record<string, any>) {
+    if (!data) {
+      return;
+    }
     // If the event is not the first event, we need to prefix it with a `,` so
     // that we end up with a list of events
     const prefix = this.added > 0 ? ',' : '';
@@ -35,7 +38,7 @@ export class Compressor {
     this.deflate.push(prefix + JSON.stringify(data), constants.Z_NO_FLUSH);
     this.added++;
 
-    return true;
+    return;
   }
 
   finish() {


### PR DESCRIPTION
Fixes https://github.com/getsentry/sentry-replay/issues/276