### PR TITLE
ref: Use `@sentry/core` transport instead of `fetch` directly

### DIFF
--- a/src/coreHandlers/handleScope-unit.test.ts
+++ b/src/coreHandlers/handleScope-unit.test.ts
@@ -9,17 +9,7 @@ let mockHandleScope: jest.MockedFunction<typeof HandleScope.handleScope>;
 jest.useFakeTimers();
 
 beforeAll(async function () {
-  const { replay } = await mockSdk();
-  type MockSendReplayRequest = jest.MockedFunction<
-    typeof replay.sendReplayRequest
-  >;
-  const mockSendReplayRequest =
-    replay.sendReplayRequest as MockSendReplayRequest;
-  mockSendReplayRequest.mockImplementation(
-    jest.fn(async () => {
-      return;
-    })
-  );
+  await mockSdk();
   jest.spyOn(HandleScope, 'handleScope');
   mockHandleScope = HandleScope.handleScope as jest.MockedFunction<
     typeof HandleScope.handleScope

--- a/src/flush.test.ts
+++ b/src/flush.test.ts
@@ -62,7 +62,7 @@ beforeAll(async () => {
   mockSendReplay = replay.sendReplay as MockSendReplay;
   mockSendReplay.mockImplementation(
     jest.fn(async () => {
-      return true;
+      return;
     })
   );
 

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -35,6 +35,10 @@ describe('Replay', () => {
   let replay: Replay;
   const prevLocation = window.location;
 
+  type MockSendReplayRequest = jest.MockedFunction<
+    typeof replay.sendReplayRequest
+  >;
+  let mockSendReplayRequest: MockSendReplayRequest;
   let domHandler: (args: any) => any;
   const { record: mockRecord } = mockRrweb();
   let mockTransport: MockTransport;
@@ -62,6 +66,8 @@ describe('Replay', () => {
   beforeEach(() => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
     replay.eventBuffer?.destroy();
+    jest.spyOn(replay, 'sendReplayRequest');
+    mockSendReplayRequest = replay.sendReplayRequest as MockSendReplayRequest;
   });
 
   afterEach(async () => {
@@ -78,6 +84,7 @@ describe('Replay', () => {
     replay.clearSession();
     replay.loadSession({ expiry: SESSION_IDLE_DURATION });
     jest.clearAllMocks();
+    mockSendReplayRequest.mockRestore();
     mockRecord.takeFullSnapshot.mockClear();
     // @ts-expect-error private
     replay.lastActivity = BASE_TIMESTAMP;
@@ -259,6 +266,7 @@ describe('Replay', () => {
     await advanceTimers(ELAPSED);
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
     expect(replay).toHaveSentReplay({ events: JSON.stringify([TEST_EVENT]) });
 
     // No user activity to trigger an update
@@ -527,6 +535,124 @@ describe('Replay', () => {
     expect(replay.session?.segmentId).toBe(1);
   });
 
+  it('fails to upload data on first two calls and succeeds on the third', async () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    // Suppress console.errors
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    const mockConsole = console.error as jest.MockedFunction<
+      typeof console.error
+    >;
+    // fail the first and second requests and pass the third one
+    mockSendReplayRequest.mockImplementationOnce(() => {
+      throw new Error('Something bad happened');
+    });
+    mockRecord._emitter(TEST_EVENT);
+
+    await advanceTimers(5000);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
+    expect(replay).not.toHaveSentReplay();
+
+    mockSendReplayRequest.mockReset();
+    mockSendReplayRequest.mockImplementationOnce(() => {
+      throw new Error('Something bad happened');
+    });
+    await advanceTimers(5000);
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
+    expect(replay).not.toHaveSentReplay();
+
+    // next tick should retry and succeed
+    mockConsole.mockRestore();
+    mockSendReplayRequest.mockReset();
+
+    await advanceTimers(8000);
+    expect(replay.sendReplayRequest).not.toHaveBeenCalled();
+    mockSendReplayRequest.mockRestore();
+    await advanceTimers(2000);
+
+    expect(replay).toHaveSentReplay({
+      replayEventPayload: expect.objectContaining({
+        error_ids: [],
+        replay_id: expect.any(String),
+        replay_start_timestamp: BASE_TIMESTAMP / 1000,
+        // 20seconds = Add up all of the previous `advanceTimers()`
+        timestamp: (BASE_TIMESTAMP + 20000) / 1000,
+        trace_ids: [],
+        urls: ['http://localhost/'],
+      }),
+      recordingPayloadHeader: { segment_id: 0 },
+      events: JSON.stringify([TEST_EVENT]),
+    });
+    mockTransport.mockClear();
+
+    // No activity has occurred, session's last activity should remain the same
+    expect(replay.session?.lastActivity).toBeGreaterThanOrEqual(BASE_TIMESTAMP);
+    expect(replay.session?.segmentId).toBe(1);
+
+    // next tick should do nothing
+    await advanceTimers(5000);
+    expect(replay).not.toHaveSentReplay();
+  });
+
+  it('fails to upload data and hits retry max and stops', async () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    jest.spyOn(replay, 'sendReplay');
+    // Suppress console.errors
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    const mockConsole = console.error as jest.MockedFunction<
+      typeof console.error
+    >;
+
+    expect(replay.session?.segmentId).toBe(0);
+
+    // fail the first and second requests and pass the third one
+    mockSendReplayRequest.mockReset();
+    mockSendReplayRequest.mockImplementation(() => {
+      throw new Error('Something bad happened');
+    });
+    mockRecord._emitter(TEST_EVENT);
+
+    await advanceTimers(5000);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
+
+    await advanceTimers(5000);
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(2);
+
+    await advanceTimers(10000);
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(3);
+
+    await advanceTimers(30000);
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(4);
+    expect(replay.sendReplay).toHaveBeenCalledTimes(4);
+
+    mockConsole.mockReset();
+
+    // Make sure it doesn't retry again
+    jest.runAllTimers();
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(4);
+    expect(replay.sendReplay).toHaveBeenCalledTimes(4);
+
+    // Retries = 3 (total tries = 4 including initial attempt)
+    // + last exception is max retries exceeded
+    expect(
+      CaptureInternalException.captureInternalException
+    ).toHaveBeenCalledTimes(5);
+    expect(
+      CaptureInternalException.captureInternalException
+    ).toHaveBeenLastCalledWith(
+      new Error('Unable to send Replay - max retries exceeded')
+    );
+
+    // No activity has occurred, session's last activity should remain the same
+    expect(replay.session?.lastActivity).toBe(BASE_TIMESTAMP);
+
+    // segmentId increases despite error
+    expect(replay.session?.segmentId).toBe(1);
+  });
+
   it('increases segment id after each event', async () => {
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
@@ -591,6 +717,57 @@ describe('Replay', () => {
         urls: ['http://localhost/'], // this doesn't truly test if we are capturing the right URL as we don't change URLs, but good enough
       }),
     });
+  });
+
+  // TODO: ... this doesn't really test anything anymore since replay event and recording are sent in the same envelope
+  it('does not create replay event if recording upload completely fails', async () => {
+    const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+    // Suppress console.errors
+    jest.spyOn(console, 'error').mockImplementation(jest.fn());
+    const mockConsole = console.error as jest.MockedFunction<
+      typeof console.error
+    >;
+    // fail the first and second requests and pass the third one
+    mockSendReplayRequest.mockImplementationOnce(() => {
+      throw new Error('Something bad happened');
+    });
+    mockRecord._emitter(TEST_EVENT);
+
+    await advanceTimers(5000);
+
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+
+    // Reset console.error mock to minimize the amount of time we are hiding
+    // console messages in case an error happens after
+    mockConsole.mockClear();
+    expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
+
+    mockSendReplayRequest.mockImplementationOnce(() => {
+      throw new Error('Something bad happened');
+    });
+    await advanceTimers(5000);
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(2);
+
+    // next tick should retry and fail
+    mockConsole.mockClear();
+
+    mockSendReplayRequest.mockImplementationOnce(() => {
+      throw new Error('Something bad happened');
+    });
+    await advanceTimers(10000);
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(3);
+
+    mockSendReplayRequest.mockImplementationOnce(() => {
+      throw new Error('Something bad happened');
+    });
+    await advanceTimers(30000);
+    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(4);
+
+    // No activity has occurred, session's last activity should remain the same
+    expect(replay.session?.lastActivity).toBeGreaterThanOrEqual(BASE_TIMESTAMP);
+    expect(replay.session?.segmentId).toBe(1);
+
+    // TODO: Recording should stop and next event should do nothing
   });
 
   it('has correct timestamps when there events earlier than initial timestamp', async function () {

--- a/src/index.ts
+++ b/src/index.ts
@@ -1244,7 +1244,11 @@ export class Replay implements Integration {
     );
 
     const client = getCurrentHub().getClient();
-    return client?.getTransport()?.send(envelope);
+    try {
+      return client?.getTransport()?.send(envelope);
+    } catch {
+      throw new Error(UNABLE_TO_SEND_REPLAY);
+    }
   }
 
   resetRetries() {

--- a/src/stop.test.ts
+++ b/src/stop.test.ts
@@ -36,7 +36,6 @@ describe('Replay - stop', () => {
     ) as MockAddInstrumentationHandler;
 
     ({ replay } = await mockSdk());
-    jest.spyOn(replay, 'sendReplayRequest');
     jest.runAllTimers();
   });
 
@@ -89,7 +88,6 @@ describe('Replay - stop', () => {
     window.dispatchEvent(new Event('blur'));
     await new Promise(process.nextTick);
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
-    expect(replay.sendReplayRequest).not.toHaveBeenCalled();
     expect(replay).not.toHaveSentReplay();
     // Session's last activity should not be updated
     expect(replay.session?.lastActivity).toEqual(BASE_TIMESTAMP);
@@ -121,7 +119,6 @@ describe('Replay - stop', () => {
     window.dispatchEvent(new Event('blur'));
     jest.runAllTimers();
     await new Promise(process.nextTick);
-    expect(replay.sendReplayRequest).toHaveBeenCalled();
     expect(replay).toHaveSentReplay({
       events: JSON.stringify([
         // This event happens when we call `replay.start`

--- a/src/types.ts
+++ b/src/types.ts
@@ -10,10 +10,9 @@ export type AllPerformanceEntry =
   | PerformanceResourceTiming
   | PerformanceNavigationTiming;
 
-export interface SendReplayRequest {
-  endpoint: string;
-  events: RecordedEvents;
+export interface SendReplay {
   replayId: string;
+  events: RecordedEvents;
   segmentId: number;
   includeReplayStartTimestamp: boolean;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -11,8 +11,8 @@ export type AllPerformanceEntry =
   | PerformanceNavigationTiming;
 
 export interface SendReplay {
-  replayId: string;
   events: RecordedEvents;
+  replayId: string;
   segmentId: number;
   includeReplayStartTimestamp: boolean;
 }

--- a/test/mocks/mockSdk.ts
+++ b/test/mocks/mockSdk.ts
@@ -13,9 +13,9 @@ interface MockSdkParams {
 }
 
 class MockTransport implements Transport {
-  async send() {
+  send = jest.fn(async () => {
     return;
-  }
+  });
   async flush() {
     return true;
   }
@@ -55,7 +55,6 @@ export async function mockSdk({
   const replay = new Replay(replayOptions);
 
   init({ ...sentryOptions, integrations: [replay] });
-  jest.spyOn(replay, 'sendReplayRequest');
 
   return { replay };
 }


### PR DESCRIPTION
Due to some changes in our JS SDK, using `fetch` directly meant our ingest requests were being instrumented (only in Sentry SaaS). Some headers were being added to these requests which ended up causing a CORS issue. Change to use the core SDK transport instead. This also (presumably) gives us request retrying for free?
