### PR TITLE
feat: Remove multipe instances errors

### DIFF
--- a/src/multiple-instances.test.ts
+++ b/src/multiple-instances.test.ts
@@ -1,10 +1,52 @@
-import { expect, it } from '@jest/globals';
+import { beforeAll, expect, it, jest } from '@jest/globals';
+import * as SentryUtils from '@sentry/utils';
+import { BASE_TIMESTAMP, mockSdk } from '@test';
 
-import { Replay } from './';
+jest.useFakeTimers({ advanceTimers: true });
 
-it('throws on creating multiple instances', function () {
-  expect(() => {
-    new Replay();
-    new Replay();
-  }).toThrow();
+let domHandler: (args: any) => any;
+beforeAll(() => {
+  jest
+    .spyOn(SentryUtils, 'addInstrumentationHandler')
+    .mockImplementation((type, handler: (args: any) => any) => {
+      if (type === 'dom') {
+        domHandler = handler;
+      }
+    });
+});
+
+it('can create multiple instances', async () => {
+  jest.setSystemTime(new Date(BASE_TIMESTAMP));
+  const { replay, Replay } = await mockSdk();
+  new Replay();
+
+  replay.start();
+  replay.start();
+
+  domHandler({
+    name: 'click',
+  });
+
+  jest.advanceTimersByTime(5000);
+  await new Promise(process.nextTick);
+
+  expect(replay).toHaveSentReplay({
+    events: JSON.stringify([
+      { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 },
+      {
+        type: 5,
+        timestamp: BASE_TIMESTAMP,
+        data: {
+          tag: 'breadcrumb',
+          payload: {
+            timestamp: BASE_TIMESTAMP / 1000,
+            type: 'default',
+            category: 'ui.click',
+            message: '<unknown>',
+            data: {},
+          },
+        },
+      },
+    ]),
+  });
 });

--- a/test/mocks/mockSdk.ts
+++ b/test/mocks/mockSdk.ts
@@ -12,7 +12,7 @@ interface MockSdkParams {
   sentryOptions?: BrowserOptions;
 }
 
-class MockTransport implements Transport {
+export class MockTransport implements Transport {
   send = jest.fn(async () => {
     return;
   });
@@ -56,5 +56,5 @@ export async function mockSdk({
 
   init({ ...sentryOptions, integrations: [replay] });
 
-  return { replay };
+  return { replay, Replay };
 }


### PR DESCRIPTION
Remove the "Multiple instances" error that is thrown in the constructor when you try to initialize the integration multiple times.