### PR TITLE
feat: Do not tag transactions with `replayId` for error replays

### DIFF
--- a/src/index-handleGlobalEvent.test.ts
+++ b/src/index-handleGlobalEvent.test.ts
@@ -1,0 +1,133 @@
+// mock functions need to be imported first
+import { afterEach, beforeEach, expect, it, jest } from '@jest/globals';
+import type { RecordMock } from '@test';
+import { BASE_TIMESTAMP } from '@test';
+import { Error } from '@test/fixtures/error';
+import { Transaction } from '@test/fixtures/transaction';
+
+import { REPLAY_EVENT_NAME } from './session/constants';
+import { ReplayConfiguration } from './types';
+import { Replay } from './';
+
+jest.useFakeTimers({ advanceTimers: true });
+
+let replay: Replay;
+let mockRecord: RecordMock;
+
+async function getMockReplay(options: ReplayConfiguration = {}) {
+  const { mockSdk } = await import('../test/mocks/mockSdk');
+  const { replay } = await mockSdk({
+    replayOptions: {
+      errorSampleRate: 1.0,
+      sessionSampleRate: 0.0,
+      stickySession: false,
+      ...options,
+    },
+  });
+
+  return replay;
+}
+async function resetMocks() {
+  jest.setSystemTime(new Date(BASE_TIMESTAMP));
+  jest.clearAllMocks();
+  jest.resetModules();
+  // NOTE: The listeners added to `addInstrumentationHandler` are leaking
+  // @ts-expect-error Don't know if there's a cleaner way to clean up old event processors
+  globalThis.__SENTRY__.globalEventProcessors = [];
+  const { mockRrweb } = await import('../test/mocks/mockRrweb');
+  ({ record: mockRecord } = mockRrweb());
+  mockRecord.takeFullSnapshot.mockClear();
+}
+beforeEach(async () => {
+  await resetMocks();
+  replay = await getMockReplay();
+  jest.runAllTimers();
+});
+
+afterEach(() => {
+  replay.stop();
+});
+
+it('deletes breadcrumbs from replay events', () => {
+  const replayEvent = {
+    type: REPLAY_EVENT_NAME,
+    breadcrumbs: [{ type: 'fakecrumb' }],
+  };
+
+  // @ts-expect-error replay event type
+  expect(replay.handleGlobalEvent(replayEvent)).toEqual({
+    type: REPLAY_EVENT_NAME,
+  });
+});
+
+it('does not delete breadcrumbs from error and transaction events', () => {
+  expect(
+    replay.handleGlobalEvent({
+      breadcrumbs: [{ type: 'fakecrumb' }],
+    })
+  ).toEqual(
+    expect.objectContaining({
+      breadcrumbs: [{ type: 'fakecrumb' }],
+    })
+  );
+  expect(
+    replay.handleGlobalEvent({
+      type: 'transaction',
+      breadcrumbs: [{ type: 'fakecrumb' }],
+    })
+  ).toEqual(
+    expect.objectContaining({
+      breadcrumbs: [{ type: 'fakecrumb' }],
+    })
+  );
+});
+
+it('only tags errors with replay id, adds trace and error id to context for error samples', async () => {
+  const transaction = Transaction();
+  const error = Error();
+  // @ts-expect-error idc
+  expect(replay.handleGlobalEvent(transaction)).toEqual(
+    expect.objectContaining({
+      tags: expect.not.objectContaining({ replayId: expect.anything() }),
+    })
+  );
+  expect(replay.handleGlobalEvent(error)).toEqual(
+    expect.objectContaining({
+      tags: expect.objectContaining({ replayId: expect.any(String) }),
+    })
+  );
+
+  // @ts-expect-error private
+  expect(replay.context.traceIds).toContain('trace_id');
+  // @ts-expect-error private
+  expect(replay.context.errorIds).toContain('event_id');
+
+  jest.runAllTimers();
+  await new Promise(process.nextTick); // wait for flush
+
+  // Turns off `waitForError` mode
+  // @ts-expect-error private
+  expect(replay.waitForError).toBe(false);
+});
+
+it('tags errors and transactions with replay id for session samples', async () => {
+  await resetMocks();
+  replay = await getMockReplay({
+    sessionSampleRate: 1.0,
+    errorSampleRate: 0,
+  });
+  replay.start();
+  const transaction = Transaction();
+  const error = Error();
+  // @ts-expect-error idc
+  expect(replay.handleGlobalEvent(transaction)).toEqual(
+    expect.objectContaining({
+      tags: expect.objectContaining({ replayId: expect.any(String) }),
+    })
+  );
+  expect(replay.handleGlobalEvent(error)).toEqual(
+    expect.objectContaining({
+      tags: expect.objectContaining({ replayId: expect.any(String) }),
+    })
+  );
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -535,10 +535,15 @@ export class Replay implements Integration {
       return event;
     }
 
-    event.tags = { ...event.tags, replayId: this.session?.id };
+    // Only tag transactions with replayId if not waiting for an error
+    if (event.type !== 'transaction' || !this.waitForError) {
+      event.tags = { ...event.tags, replayId: this.session?.id };
+    }
 
+    // Collect traceIds in context regardless of `waitForError` - if it's true,
+    // context gets cleared on every checkout
     if (event.type === 'transaction') {
-      this.context.traceIds.add(String(event.contexts?.trace.trace_id || ''));
+      this.context.traceIds.add(String(event.contexts?.trace?.trace_id || ''));
       return event;
     }
 

--- a/test/fixtures/error.ts
+++ b/test/fixtures/error.ts
@@ -1,0 +1,113 @@
+import { SeverityLevel } from '@sentry/browser';
+import { Event } from '@sentry/types';
+
+export function Error(obj?: Event) {
+  const timestamp = new Date().getTime() / 1000;
+
+  return {
+    exception: {
+      values: [
+        {
+          type: 'Error',
+          value: 'testing error',
+          stacktrace: {
+            frames: [
+              {
+                filename:
+                  'webpack-internal:///../../getsentry/static/getsentry/gsApp/components/replayInit.tsx',
+                function: 'eval',
+                in_app: true,
+                lineno: 64,
+                colno: 13,
+              },
+            ],
+          },
+          mechanism: {
+            type: 'instrument',
+            handled: true,
+            data: {
+              function: 'setTimeout',
+            },
+          },
+        },
+      ],
+    },
+    level: 'error' as SeverityLevel,
+    event_id: 'event_id',
+    platform: 'javascript',
+    timestamp,
+    environment: 'prod',
+    release: 'frontend@22.11.0',
+    sdk: {
+      //{{{
+      integrations: [
+        'InboundFilters',
+        'FunctionToString',
+        'TryCatch',
+        'Breadcrumbs',
+        'GlobalHandlers',
+        'LinkedErrors',
+        'Dedupe',
+        'HttpContext',
+        'ExtraErrorData',
+        'BrowserTracing',
+      ],
+      name: 'sentry.javascript.react',
+      version: '7.18.0',
+      packages: [
+        {
+          name: 'npm:@sentry/react',
+          version: '7.18.0',
+        },
+      ],
+    }, //}}}
+    tags: {
+      //{{{
+      organization: '1',
+      'organization.slug': 'sentry-emerging-tech',
+      plan: 'am1_business_ent_auf',
+      'plan.name': 'Business',
+      'plan.max_members': 'null',
+      'plan.total_members': '15',
+      'plan.tier': 'am1',
+      'timeOrigin.mode': 'navigationStart',
+    }, //}}}
+    user: {
+      ip_address: '0.0.0.0',
+      email: 'billy@sentry.io',
+      id: '1',
+      name: 'Billy Vong',
+    },
+    contexts: {
+      organization: {
+        id: '1',
+        slug: 'sentry-emerging-tech',
+      },
+      Error: {},
+    },
+    breadcrumbs: [
+      {
+        timestamp,
+        category: 'console',
+        data: {
+          arguments: [
+            'Warning: componentWillMount has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n* Move code with side effects to componentDidMount, and set initial state in the constructor.\n* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n\nPlease update the following components: %s',
+            'Router, RouterContext',
+          ],
+          logger: 'console',
+        },
+        message:
+          'Warning: componentWillMount has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n* Move code with side effects to componentDidMount, and set initial state in the constructor.\n* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n\nPlease update the following components: %s Router, RouterContext',
+      },
+    ],
+    sdkProcessingMetadata: {},
+    request: {
+      url: 'https://example.org',
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36',
+      },
+    },
+    ...obj,
+  };
+}

--- a/test/fixtures/transaction.ts
+++ b/test/fixtures/transaction.ts
@@ -1,0 +1,306 @@
+import { Event, SeverityLevel } from '@sentry/types';
+
+export function Transaction(obj?: Partial<Event>) {
+  const timestamp = new Date().getTime() / 1000;
+
+  return {
+    contexts: {
+      //{{{
+      organization: {
+        id: '1',
+        slug: 'sentry-emerging-tech',
+      },
+      trace: {
+        op: 'navigation',
+        span_id: 'b44b173b1c74a782',
+        tags: {
+          'routing.instrumentation': 'react-router-v3',
+          from: '/organizations/:orgId/replays/',
+          'ui.longTaskCount.grouped': '<=1',
+          effectiveConnectionType: '4g',
+          deviceMemory: '8 GB',
+          hardwareConcurrency: '10',
+          sentry_reportAllChanges: false,
+        },
+        trace_id: 'trace_id',
+      },
+    }, //}}}
+    spans: [
+      //{{{
+      {
+        description: '<LoadingIndicator>',
+        op: 'ui.react.mount',
+        parent_span_id: 'b44b173b1c74a782',
+        span_id: '9ea106e8efbce4a0',
+        start_timestamp: 1668184224.4743,
+        timestamp: 1668184224.5091,
+        trace_id: '3e0ff8aff4dc4236a80b77a37ef66c7d',
+      },
+      {
+        description: '<App>',
+        op: 'ui.react.update',
+        parent_span_id: 'b44b173b1c74a782',
+        span_id: 'b4c7b421761d903a',
+        start_timestamp: 1668184224.4843998,
+        timestamp: 1668184224.5091999,
+        trace_id: '3e0ff8aff4dc4236a80b77a37ef66c7d',
+      },
+      {
+        description: 'Main UI thread blocked',
+        op: 'ui.long-task',
+        parent_span_id: 'b44b173b1c74a782',
+        span_id: '808967f15cae9251',
+        start_timestamp: 1668184224.4343,
+        timestamp: 1668184224.5483,
+        trace_id: '3e0ff8aff4dc4236a80b77a37ef66c7d',
+      },
+      {
+        data: {
+          method: 'GET',
+          url: '/api/0/projects/sentry-emerging-tech/billy-test/replays/c11bd625b0e14081a0827a22a0a9be4e/',
+          type: 'fetch',
+        },
+        description:
+          'GET /api/0/projects/sentry-emerging-tech/billy-test/replays/c11bd625b0e14081a0827a22a0a9be4e/',
+        op: 'http.client',
+        parent_span_id: 'b44b173b1c74a782',
+        span_id: '87497c337838d561',
+        start_timestamp: 1668184224.7844,
+        status: 'ok',
+        tags: {
+          'http.status_code': '200',
+        },
+        timestamp: 1668184225.0802999,
+        trace_id: '3e0ff8aff4dc4236a80b77a37ef66c7d',
+      },
+      {
+        data: {
+          'Transfer Size': 1097,
+          'Encoded Body Size': 797,
+          'Decoded Body Size': 1885,
+        },
+        description: '/favicon.ico',
+        op: 'resource.other',
+        parent_span_id: 'b44b173b1c74a782',
+        span_id: 'b7fad2cd42783af4',
+        start_timestamp: 1668184224.5532,
+        timestamp: 1668184224.5562,
+        trace_id: '3e0ff8aff4dc4236a80b77a37ef66c7d',
+      },
+    ], //}}}
+    start_timestamp: 1668184224.447,
+    tags: {
+      organization: '1',
+      'organization.slug': 'sentry-emerging-tech',
+      plan: 'am1_business_ent_auf',
+      'plan.name': 'Business',
+      'plan.max_members': 'null',
+      'plan.total_members': '15',
+      'plan.tier': 'am1',
+      'routing.instrumentation': 'react-router-v3',
+      from: '/organizations/:orgId/replays/',
+      'ui.longTaskCount.grouped': '<=1',
+      effectiveConnectionType: '4g',
+      deviceMemory: '8 GB',
+      hardwareConcurrency: '10',
+      sentry_reportAllChanges: false,
+      'timeOrigin.mode': 'navigationStart',
+    },
+    transaction: '/organizations/:orgId/replays/:replaySlug/',
+    type: 'transaction' as const,
+    sdkProcessingMetadata: {
+      //{{{
+      source: 'route',
+      dynamicSamplingContext: {
+        environment: 'prod',
+        release: 'frontend@22.11.0+e5bd7ea3280849b58158c7adf1505e7d950e7f31',
+        transaction: '/organizations/:orgId/replays/:replaySlug/',
+        public_key: '6991720ac36e4ddd9f8dc3331187628f',
+        trace_id: '3e0ff8aff4dc4236a80b77a37ef66c7d',
+        sample_rate: '1',
+      },
+      spanMetadata: {
+        '9ea106e8efbce4a0': {
+          logMessage:
+            "[Tracing] Starting 'ui.react.mount' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        b4c7b421761d903a: {
+          logMessage:
+            "[Tracing] Starting 'ui.react.update' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '808967f15cae9251': {
+          logMessage:
+            "[Tracing] Starting 'ui.long-task' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '9a0de85dfd88085c': {
+          logMessage:
+            "[Tracing] Starting 'ui.react.render' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '863c6099f1929910': {
+          logMessage:
+            "[Tracing] Starting 'ui.react.update' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '87497c337838d561': {
+          logMessage:
+            "[Tracing] Starting 'http.client' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '81638bb5251f9e3f': {
+          logMessage:
+            "[Tracing] Starting 'http.client' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        bf25ff92b2dc7498: {
+          logMessage:
+            "[Tracing] Starting 'ui.long-task' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        a7c3320e88b04076: {
+          logMessage:
+            "[Tracing] Starting 'ui.react.update' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '95c892e987b8e0f5': {
+          logMessage:
+            "[Tracing] Starting 'ui.long-task' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        b734c15c4d94b7b6: {
+          logMessage:
+            "[Tracing] Starting 'ui.long-task' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '934881bfe9a8e043': {
+          logMessage:
+            "[Tracing] Starting 'http.client' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '9bc8a019012e4692': {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        b3c5eb78c15aa492: {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '84a72c34a78232b7': {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        b523103902ac1f0d: {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '84f863de30175a64': {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        b0532b585ec47f05: {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '9c3612dc22c5aea5': {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '82b74a44ef06ae13': {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        b2d11e8d407329fd: {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        '98146db11c338f31': {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        a05774f4b2885c47: {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        a0c0d4f8ec6bfcd7: {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        ab2e6ef0852bfc64: {
+          logMessage:
+            "[Tracing] Starting 'resource.script' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+        b7fad2cd42783af4: {
+          logMessage:
+            "[Tracing] Starting 'resource.other' span on transaction '/organizations/:orgId/replays/:replaySlug/' (b44b173b1c74a782).",
+        },
+      },
+      changes: [],
+      propagations: 2,
+      sampleRate: 1,
+    }, //}}}
+    transaction_info: {
+      source: 'route',
+      changes: [],
+      propagations: 2,
+    },
+    measurements: {
+      longTaskCount: {
+        value: 0,
+        unit: '',
+      },
+      longTaskDuration: {
+        value: 0,
+        unit: '',
+      },
+    },
+    platform: 'javascript',
+    event_id: 'f02630b140c0431fb6c8809f5b06d8be',
+    environment: 'prod',
+    release: 'frontend@22.11.0',
+    sdk: {
+      integrations: [
+        'InboundFilters',
+        'FunctionToString',
+        'TryCatch',
+        'Breadcrumbs',
+        'GlobalHandlers',
+        'LinkedErrors',
+        'Dedupe',
+        'HttpContext',
+        'ExtraErrorData',
+        'BrowserTracing',
+      ],
+      name: 'sentry.javascript.react',
+      version: '7.18.0',
+      packages: [
+        {
+          name: 'npm:@sentry/react',
+          version: '7.18.0',
+        },
+      ],
+    },
+    user: {
+      ip_address: '0.0.0.0',
+      email: 'billy@sentry.io',
+      id: '1',
+      name: 'Billy Vong',
+    },
+    breadcrumbs: [
+      {
+        timestamp,
+        category: 'console',
+        data: {
+          arguments: [
+            'Warning: componentWillMount has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n* Move code with side effects to componentDidMount, and set initial state in the constructor.\n* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n\nPlease update the following components: %s',
+            'Router, RouterContext',
+          ],
+          logger: 'console',
+        },
+        level: 'warning' as SeverityLevel,
+        message:
+          'Warning: componentWillMount has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.\n\n* Move code with side effects to componentDidMount, and set initial state in the constructor.\n* Rename componentWillMount to UNSAFE_componentWillMount to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.\n\nPlease update the following components: %s Router, RouterContext',
+      },
+    ],
+    request: {
+      url: 'https://example.org',
+      headers: {
+        'User-Agent':
+          'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/107.0.0.0 Safari/537.36',
+      },
+    },
+
+    timestamp,
+    ...obj,
+  };
+}


### PR DESCRIPTION
With error sessions, we do not want to tag transactions with the replayId as there is no guarantee that the replay will exist (since replay is only created when an error happens).

Fixes https://github.com/getsentry/sentry/issues/41183