### PR TITLE
feat: Tag sampling rates + type on replay_event

### DIFF
--- a/src/index-errorSampleRate.test.ts
+++ b/src/index-errorSampleRate.test.ts
@@ -119,6 +119,13 @@ describe('Replay (errorSampleRate)', () => {
     await new Promise(process.nextTick);
 
     expect(replay).toHaveSentReplay({
+      replayEventPayload: expect.objectContaining({
+        tags: expect.objectContaining({
+          errorSampleRate: 1,
+          replayType: 'error',
+          sessionSampleRate: 0,
+        }),
+      }),
       events: JSON.stringify([
         { data: { isCheckout: true }, timestamp: BASE_TIMESTAMP, type: 2 },
         TEST_EVENT,

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -807,6 +807,11 @@ describe('Replay', () => {
       replayEventPayload: expect.objectContaining({
         replay_start_timestamp: (BASE_TIMESTAMP - 10000) / 1000,
         urls: ['http://localhost/'], // this doesn't truly test if we are capturing the right URL as we don't change URLs, but good enough
+        tags: expect.objectContaining({
+          errorSampleRate: 0,
+          replayType: 'session',
+          sessionSampleRate: 1,
+        }),
       }),
     });
   });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1237,9 +1237,17 @@ export class Replay implements Integration {
           if (session) {
             client._updateSessionFromEvent(session, preparedEvent);
           }
+
           preparedEvent.sdk = {
             ...preparedEvent.sdk,
             ...sdkInfo,
+          };
+
+          preparedEvent.tags = {
+            ...preparedEvent.tags,
+            sessionSampleRate: this.options.sessionSampleRate,
+            errorSampleRate: this.options.errorSampleRate,
+            replayType: this.session?.sampled,
           };
 
           resolve(preparedEvent);


### PR DESCRIPTION
Add tags for `sessionSampleRate`, `errorSampleRate`, and `replayType` (`error` or `sample`). Right now these are added as tags for debugging purposes.