### PR TITLE
docs: Min version req applies to *all* SDKs

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Note: Session Replay is currently in beta.
 
 ## Pre-requisites
 
-For the sentry-replay integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser), or an equivalent framework SDK (e.g. [@sentry/react](https://www.npmjs.com/package/@sentry/react)) installed, minimum version `7.x`.
+For the sentry-replay integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser), or an equivalent framework SDK (e.g. [@sentry/react](https://www.npmjs.com/package/@sentry/react)) installed. The minimum version required for the SDK is `7.x`.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Note: Session Replay is currently in beta.
 
 ## Pre-requisites
 
-For the sentry-replay integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser) (minimum version `7.x`), or an equivalent framework SDK (e.g. [@sentry/react](https://www.npmjs.com/package/@sentry/react)) installed.
+For the sentry-replay integration to work, you must have the [Sentry browser SDK package](https://www.npmjs.com/package/@sentry/browser), or an equivalent framework SDK (e.g. [@sentry/react](https://www.npmjs.com/package/@sentry/react)) installed, minimum version `7.x`.
 
 ## Installation
 


### PR DESCRIPTION
Based on feedback from customer:
"Since we are using @sentry/react, I didn’t realize that the 7.x version was required, since the way it was worded led me to assume it only applied to the sentry browser package. Once I updated @sentry/react to version 7 everything started working."