### PR TITLE
feat: Fix empty URLs on failed uploads

### DIFF
--- a/jest.setup.ts
+++ b/jest.setup.ts
@@ -93,7 +93,7 @@ const toHaveSentReplay: MatcherFunction<
   const envelopeItems = lastCall?.[1] || [[], []];
   const [
     [replayEventHeader, replayEventPayload],
-    [recordingHeader, recordingPayload],
+    [recordingHeader, recordingPayload] = [],
   ] = envelopeItems;
 
   // @ts-expect-error recordingPayload is always a string in our tests

--- a/src/flush.test.ts
+++ b/src/flush.test.ts
@@ -194,6 +194,7 @@ it('long first flush enqueues following events', async () => {
     replayId: expect.any(String),
     includeReplayStartTimestamp: true,
     segmentId: 0,
+    eventContext: expect.anything(),
   });
 
   // Add this to test that segment ID increases
@@ -237,6 +238,7 @@ it('long first flush enqueues following events', async () => {
     replayId: expect.any(String),
     includeReplayStartTimestamp: false,
     segmentId: 1,
+    eventContext: expect.anything(),
   });
 
   // Make sure there's no other calls

--- a/src/index-errorSampleRate.test.ts
+++ b/src/index-errorSampleRate.test.ts
@@ -2,7 +2,6 @@ jest.unmock('@sentry/browser');
 
 // mock functions need to be imported first
 import {
-  afterAll,
   afterEach,
   beforeEach,
   describe,
@@ -19,7 +18,6 @@ import { DomHandler, MockTransportSend } from '@test/types';
 
 import {
   REPLAY_SESSION_KEY,
-  SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
 } from './session/constants';
 import { Replay } from './';
@@ -48,17 +46,8 @@ describe('Replay (errorSampleRate)', () => {
   });
 
   afterEach(async () => {
-    jest.runAllTimers();
-    await new Promise(process.nextTick);
-    jest.setSystemTime(new Date(BASE_TIMESTAMP));
-    replay.stop();
     replay.clearSession();
-    replay.eventBuffer?.destroy();
-    replay.loadSession({ expiry: SESSION_IDLE_DURATION });
-  });
-
-  afterAll(() => {
-    replay && replay.stop();
+    replay.stop();
   });
 
   it('uploads a replay when `Sentry.captureException` is called and continues recording', async () => {

--- a/src/index-sampling.test.ts
+++ b/src/index-sampling.test.ts
@@ -26,10 +26,12 @@ describe('Replay (sampling)', () => {
 
     expect(replay.session?.sampled).toBe(false);
     // @ts-expect-error private
-    expect(replay.initialState).toEqual({
-      timestamp: expect.any(Number),
-      url: 'http://localhost/',
-    });
+    expect(replay.context).toEqual(
+      expect.objectContaining({
+        initialTimestamp: expect.any(Number),
+        initialUrl: 'http://localhost/',
+      })
+    );
     expect(mockRecord).not.toHaveBeenCalled();
     expect(replay.addListeners).not.toHaveBeenCalled();
   });

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -85,7 +85,7 @@ describe('Replay', () => {
     jest.clearAllMocks();
     mockSendReplayRequest.mockRestore();
     mockRecord.takeFullSnapshot.mockClear();
-    replay && replay.stop();
+    replay.stop();
   });
 
   it('calls rrweb.record with custom options', async () => {

--- a/src/index.test.ts
+++ b/src/index.test.ts
@@ -1,5 +1,6 @@
+jest.mock('./util/isInternal', () => ({ isInternal: jest.fn(() => true) }));
+
 import {
-  afterAll,
   afterEach,
   beforeAll,
   beforeEach,
@@ -8,19 +9,16 @@ import {
   it,
   jest,
 } from '@jest/globals';
-import { getCurrentHub } from '@sentry/core';
-import { Transport } from '@sentry/types';
-import * as SentryUtils from '@sentry/utils';
-import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
+import { BASE_TIMESTAMP, RecordMock } from '@test';
 import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
+import { resetSdkMock } from '@test/mocks';
+import { DomHandler, MockTransportSend } from '@test/types';
 
 import {
   MAX_SESSION_LIFE,
   REPLAY_SESSION_KEY,
-  SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
 } from './session/constants';
-import * as CaptureInternalException from './util/captureInternalException';
 import { Replay } from './';
 
 jest.useFakeTimers({ advanceTimers: true });
@@ -30,71 +28,72 @@ async function advanceTimers(time: number) {
   await new Promise(process.nextTick);
 }
 
-type MockTransport = jest.MockedFunction<Transport['send']>;
 describe('Replay', () => {
   let replay: Replay;
+  let mockRecord: RecordMock;
+  let mockTransportSend: MockTransportSend;
+  let domHandler: DomHandler;
+  let spyCaptureException: jest.MockedFunction<any>;
   const prevLocation = window.location;
 
   type MockSendReplayRequest = jest.MockedFunction<
     typeof replay.sendReplayRequest
   >;
   let mockSendReplayRequest: MockSendReplayRequest;
-  let domHandler: (args: any) => any;
-  const { record: mockRecord } = mockRrweb();
-  let mockTransport: MockTransport;
-
-  jest.spyOn(CaptureInternalException, 'captureInternalException');
 
   beforeAll(async () => {
     jest.setSystemTime(new Date(BASE_TIMESTAMP));
-    jest
-      .spyOn(SentryUtils, 'addInstrumentationHandler')
-      .mockImplementation((type, handler: (args: any) => any) => {
-        if (type === 'dom') {
-          domHandler = handler;
-        }
-      });
-
-    ({ replay } = await mockSdk());
     jest.runAllTimers();
-    jest.spyOn(replay, 'flush');
-    jest.spyOn(replay, 'runFlush');
-    mockTransport = getCurrentHub()?.getClient()?.getTransport()
-      ?.send as MockTransport;
   });
 
-  beforeEach(() => {
-    jest.setSystemTime(new Date(BASE_TIMESTAMP));
-    replay.eventBuffer?.destroy();
+  beforeEach(async () => {
+    ({
+      mockRecord,
+      mockTransportSend,
+      domHandler,
+      replay,
+      spyCaptureException,
+    } = await resetSdkMock({
+      sessionSampleRate: 1.0,
+      errorSampleRate: 0.0,
+      stickySession: true,
+    }));
+
+    jest.spyOn(replay, 'flush');
+    jest.spyOn(replay, 'runFlush');
     jest.spyOn(replay, 'sendReplayRequest');
+
+    // Create a new session and clear mocks because a segment (from initial
+    // checkout) will have already been uploaded by the time the tests run
+    replay.clearSession();
+    replay.loadSession({ expiry: 0 });
+    mockTransportSend.mockClear();
     mockSendReplayRequest = replay.sendReplayRequest as MockSendReplayRequest;
+    mockSendReplayRequest.mockClear();
   });
 
   afterEach(async () => {
     jest.runAllTimers();
     await new Promise(process.nextTick);
-    jest.setSystemTime(new Date(BASE_TIMESTAMP));
     // @ts-expect-error: The operand of a 'delete' operator must be optional.ts(2790)
     delete window.location;
     Object.defineProperty(window, 'location', {
       value: prevLocation,
       writable: true,
     });
-    sessionStorage.clear();
     replay.clearSession();
-    replay.loadSession({ expiry: SESSION_IDLE_DURATION });
     jest.clearAllMocks();
     mockSendReplayRequest.mockRestore();
     mockRecord.takeFullSnapshot.mockClear();
-    // @ts-expect-error private
-    replay.lastActivity = BASE_TIMESTAMP;
-  });
-
-  afterAll(() => {
     replay && replay.stop();
   });
 
   it('calls rrweb.record with custom options', async () => {
+    ({ mockRecord, mockTransportSend, domHandler, replay } = await resetSdkMock(
+      {
+        ignoreClass: 'sentry-test-ignore',
+      }
+    ));
     expect(mockRecord.mock.calls[0][0]).toMatchInlineSnapshot(`
       {
         "blockClass": "sentry-block",
@@ -266,7 +265,7 @@ describe('Replay', () => {
     await advanceTimers(ELAPSED);
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
-    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
+    expect(mockTransportSend).toHaveBeenCalledTimes(1);
     expect(replay).toHaveSentReplay({ events: JSON.stringify([TEST_EVENT]) });
 
     // No user activity to trigger an update
@@ -295,7 +294,7 @@ describe('Replay', () => {
     });
 
     // There should also not be another attempt at an upload 5 seconds after the last replay event
-    mockTransport.mockClear();
+    mockTransportSend.mockClear();
     await advanceTimers(5000);
 
     expect(replay).not.toHaveSentReplay();
@@ -306,7 +305,7 @@ describe('Replay', () => {
     expect(replay.eventBuffer?.length).toBe(0);
 
     // Let's make sure it continues to work
-    mockTransport.mockClear();
+    mockTransportSend.mockClear();
     mockRecord._emitter(TEST_EVENT);
     await advanceTimers(5000);
     expect(replay).toHaveSentReplay({ events: JSON.stringify([TEST_EVENT]) });
@@ -317,10 +316,12 @@ describe('Replay', () => {
 
     expect(initialSession?.id).toBeDefined();
     // @ts-expect-error private member
-    expect(replay.initialState).toEqual({
-      url: 'http://localhost/',
-      timestamp: BASE_TIMESTAMP,
-    });
+    expect(replay.context).toEqual(
+      expect.objectContaining({
+        initialUrl: 'http://localhost/',
+        initialTimestamp: BASE_TIMESTAMP,
+      })
+    );
 
     const url = 'http://dummy/';
     Object.defineProperty(window, 'location', {
@@ -387,12 +388,14 @@ describe('Replay', () => {
       ]),
     });
 
-    // `initialState` should be reset when a new session is created
+    // `context` should be reset when a new session is created
     // @ts-expect-error private member
-    expect(replay.initialState).toEqual({
-      url: 'http://dummy/',
-      timestamp: newTimestamp,
-    });
+    expect(replay.context).toEqual(
+      expect.objectContaining({
+        initialUrl: 'http://dummy/',
+        initialTimestamp: newTimestamp,
+      })
+    );
   });
 
   it('does not record if user has been idle for more than MAX_SESSION_LIFE and only starts a new session after a user action', async () => {
@@ -401,10 +404,12 @@ describe('Replay', () => {
 
     expect(initialSession?.id).toBeDefined();
     // @ts-expect-error private member
-    expect(replay.initialState).toEqual({
-      url: 'http://localhost/',
-      timestamp: BASE_TIMESTAMP,
-    });
+    expect(replay.context).toEqual(
+      expect.objectContaining({
+        initialUrl: 'http://localhost/',
+        initialTimestamp: BASE_TIMESTAMP,
+      })
+    );
 
     const url = 'http://dummy/';
     Object.defineProperty(window, 'location', {
@@ -496,12 +501,14 @@ describe('Replay', () => {
       ]),
     });
 
-    // `initialState` should be reset when a new session is created
+    // `context` should be reset when a new session is created
     // @ts-expect-error private member
-    expect(replay.initialState).toEqual({
-      url: 'http://dummy/',
-      timestamp: newTimestamp,
-    });
+    expect(replay.context).toEqual(
+      expect.objectContaining({
+        initialUrl: 'http://dummy/',
+        initialTimestamp: newTimestamp,
+      })
+    );
   });
 
   it('uploads a dom breadcrumb 5 seconds after listener receives an event', async () => {
@@ -536,39 +543,32 @@ describe('Replay', () => {
   });
 
   it('fails to upload data on first two calls and succeeds on the third', async () => {
+    expect(replay.session?.segmentId).toBe(0);
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
+
     // Suppress console.errors
     jest.spyOn(console, 'error').mockImplementation(jest.fn());
     const mockConsole = console.error as jest.MockedFunction<
       typeof console.error
     >;
+
     // fail the first and second requests and pass the third one
-    mockSendReplayRequest.mockImplementationOnce(() => {
+    mockTransportSend.mockImplementationOnce(() => {
       throw new Error('Something bad happened');
     });
     mockRecord._emitter(TEST_EVENT);
-
     await advanceTimers(5000);
 
     expect(mockRecord.takeFullSnapshot).not.toHaveBeenCalled();
-    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
-    expect(replay).not.toHaveSentReplay();
-
-    mockSendReplayRequest.mockReset();
-    mockSendReplayRequest.mockImplementationOnce(() => {
+    mockTransportSend.mockImplementationOnce(() => {
       throw new Error('Something bad happened');
     });
     await advanceTimers(5000);
-    expect(replay.sendReplayRequest).toHaveBeenCalledTimes(1);
-    expect(replay).not.toHaveSentReplay();
 
     // next tick should retry and succeed
     mockConsole.mockRestore();
-    mockSendReplayRequest.mockReset();
 
     await advanceTimers(8000);
-    expect(replay.sendReplayRequest).not.toHaveBeenCalled();
-    mockSendReplayRequest.mockRestore();
     await advanceTimers(2000);
 
     expect(replay).toHaveSentReplay({
@@ -577,15 +577,15 @@ describe('Replay', () => {
         replay_id: expect.any(String),
         replay_start_timestamp: BASE_TIMESTAMP / 1000,
         // 20seconds = Add up all of the previous `advanceTimers()`
-        timestamp: (BASE_TIMESTAMP + 20000) / 1000,
+        timestamp: (BASE_TIMESTAMP + 20000) / 1000 + 0.02,
         trace_ids: [],
         urls: ['http://localhost/'],
       }),
       recordingPayloadHeader: { segment_id: 0 },
       events: JSON.stringify([TEST_EVENT]),
     });
-    mockTransport.mockClear();
 
+    mockTransportSend.mockClear();
     // No activity has occurred, session's last activity should remain the same
     expect(replay.session?.lastActivity).toBeGreaterThanOrEqual(BASE_TIMESTAMP);
     expect(replay.session?.segmentId).toBe(1);
@@ -598,6 +598,7 @@ describe('Replay', () => {
   it('fails to upload data and hits retry max and stops', async () => {
     const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
     jest.spyOn(replay, 'sendReplay');
+
     // Suppress console.errors
     jest.spyOn(console, 'error').mockImplementation(jest.fn());
     const mockConsole = console.error as jest.MockedFunction<
@@ -635,14 +636,11 @@ describe('Replay', () => {
     expect(replay.sendReplayRequest).toHaveBeenCalledTimes(4);
     expect(replay.sendReplay).toHaveBeenCalledTimes(4);
 
+    expect(spyCaptureException).toHaveBeenCalledTimes(5);
     // Retries = 3 (total tries = 4 including initial attempt)
     // + last exception is max retries exceeded
-    expect(
-      CaptureInternalException.captureInternalException
-    ).toHaveBeenCalledTimes(5);
-    expect(
-      CaptureInternalException.captureInternalException
-    ).toHaveBeenLastCalledWith(
+    expect(spyCaptureException).toHaveBeenCalledTimes(5);
+    expect(spyCaptureException).toHaveBeenLastCalledWith(
       new Error('Unable to send Replay - max retries exceeded')
     );
 
@@ -771,6 +769,9 @@ describe('Replay', () => {
   });
 
   it('has correct timestamps when there events earlier than initial timestamp', async function () {
+    replay.clearSession();
+    replay.loadSession({ expiry: 0 });
+    mockTransportSend.mockClear();
     Object.defineProperty(document, 'visibilityState', {
       configurable: true,
       get: function () {
@@ -818,23 +819,27 @@ describe('Replay', () => {
 
   it('does not have stale `replay_start_timestamp` due to an old time origin', async function () {
     const ELAPSED = 86400000 * 2; // 2 days
-    // Change time origin to something very old (this happens in the browser
-    // when a tab has sat idle for a long period and user comes back to it)
-    // @ts-expect-error read-only
-    SentryUtils.browserPerformanceTimeOrigin = BASE_TIMESTAMP - ELAPSED;
+    // Add a mock performance event that happens 2 days ago. This can happen in the browser
+    // when a tab has sat idle for a long period and user comes back to it.
+    //
+    // We pass a negative start time as it's a bit difficult to mock
+    // `@sentry/utils/browserPerformanceTimeOrigin`. This would not happen in
+    // real world.
+    replay.performanceEvents.push(
+      PerformanceEntryResource({
+        startTime: -ELAPSED,
+      })
+    );
 
-    // add a mock performance event
-    replay.performanceEvents.push(PerformanceEntryResource());
-
-    // This should be null because `addEvent` has not been called
+    // This should be null because `addEvent` has not been called yet
     // @ts-expect-error private member
     expect(replay.context.earliestEvent).toBe(null);
-    expect(mockTransport).toHaveBeenCalledTimes(0);
+    expect(mockTransportSend).toHaveBeenCalledTimes(0);
 
     // A new checkout occurs (i.e. a new session was started)
     const TEST_EVENT = {
       data: {},
-      timestamp: BASE_TIMESTAMP / 1000,
+      timestamp: BASE_TIMESTAMP,
       type: 2,
     };
 
@@ -844,7 +849,7 @@ describe('Replay', () => {
     jest.runAllTimers();
     await new Promise(process.nextTick);
 
-    expect(mockTransport).toHaveBeenCalledTimes(1);
+    expect(mockTransportSend).toHaveBeenCalledTimes(1);
     expect(replay).toHaveSentReplay({
       replayEventPayload: expect.objectContaining({
         // Make sure the old performance event is thrown out

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,13 +37,13 @@ import {
 import { createEventBuffer, IEventBuffer } from './eventBuffer';
 import type {
   AllPerformanceEntry,
-  InitialState,
   InstrumentationTypeBreadcrumb,
   InstrumentationTypeSpan,
+  InternalEventContext,
+  PopEventContext,
   RecordingEvent,
   RecordingOptions,
   ReplayConfiguration,
-  ReplayEventContext,
   ReplayPluginOptions,
   SendReplay,
 } from './types';
@@ -130,16 +130,13 @@ export class Replay implements Integration {
    */
   private stopRecording: ReturnType<typeof record> | null = null;
 
-  /**
-   * Captured state when integration is first initialized
-   */
-  private initialState: InitialState;
-
-  private context: ReplayEventContext = {
+  private context: InternalEventContext = {
     errorIds: new Set(),
     traceIds: new Set(),
     urls: [],
     earliestEvent: null,
+    initialTimestamp: new Date().getTime(),
+    initialUrl: '',
   };
 
   session: Session | undefined;
@@ -399,11 +396,9 @@ export class Replay implements Integration {
 
     // Reset context as well
     this.clearContext();
-    this.initialState = {
-      timestamp: new Date().getTime(),
-      url,
-    };
 
+    this.context.initialUrl = url;
+    this.context.initialTimestamp = new Date().getTime();
     this.context.urls.push(url);
   }
 
@@ -1049,6 +1044,7 @@ export class Replay implements Integration {
    * Clear context
    */
   clearContext() {
+    // XXX: `initialTimestamp` and `initialUrl` do not get cleared
     this.context.errorIds.clear();
     this.context.traceIds.clear();
     this.context.urls = [];
@@ -1058,18 +1054,17 @@ export class Replay implements Integration {
   /**
    * Return and clear context
    */
-  popEventContext() {
-    const initialState = this.initialState;
+  popEventContext(): PopEventContext {
     if (
-      this.initialState &&
       this.context.earliestEvent &&
-      this.context.earliestEvent < this.initialState.timestamp
+      this.context.earliestEvent < this.context.initialTimestamp
     ) {
-      initialState.timestamp = this.context.earliestEvent;
+      this.context.initialTimestamp = this.context.earliestEvent;
     }
 
     const context = {
-      initialState,
+      initialTimestamp: this.context.initialTimestamp,
+      initialUrl: this.context.initialUrl,
       errorIds: Array.from(this.context.errorIds).filter(Boolean),
       traceIds: Array.from(this.context.traceIds).filter(Boolean),
       urls: this.context.urls,
@@ -1108,15 +1103,17 @@ export class Replay implements Integration {
     const replayId = this.session.id;
     // Always increment segmentId regardless of outcome of sending replay
     const segmentId = this.session.segmentId++;
+    const recordingData = await this.eventBuffer.finish();
+    const eventContext = this.popEventContext();
 
     try {
       // Note this empties the event buffer regardless of outcome of sending replay
-      const recordingData = await this.eventBuffer.finish();
       await this.sendReplay({
         replayId,
         events: recordingData,
         segmentId,
         includeReplayStartTimestamp: segmentId === 0,
+        eventContext,
       });
     } catch (err) {
       captureInternalException(err);
@@ -1195,6 +1192,7 @@ export class Replay implements Integration {
     replayId: event_id,
     segmentId: segment_id,
     includeReplayStartTimestamp,
+    eventContext,
   }: SendReplay) {
     const payloadWithSequence = createPayload({
       events,
@@ -1203,9 +1201,9 @@ export class Replay implements Integration {
       },
     });
 
-    const { urls, errorIds, traceIds, initialState } = this.popEventContext();
+    const { urls, errorIds, traceIds, initialTimestamp } = eventContext;
 
-    const timestamp = new Date().getTime();
+    const currentTimestamp = new Date().getTime();
 
     const sdkInfo = {
       name: 'sentry.javascript.integration.replay',
@@ -1221,9 +1219,9 @@ export class Replay implements Integration {
             {
               type: REPLAY_EVENT_NAME,
               ...(includeReplayStartTimestamp
-                ? { replay_start_timestamp: initialState.timestamp / 1000 }
+                ? { replay_start_timestamp: initialTimestamp / 1000 }
                 : {}),
-              timestamp: timestamp / 1000,
+              timestamp: currentTimestamp / 1000,
               error_ids: errorIds,
               trace_ids: traceIds,
               urls,
@@ -1296,8 +1294,9 @@ export class Replay implements Integration {
     events,
     segmentId,
     includeReplayStartTimestamp,
+    eventContext,
   }: SendReplay) {
-    // short circuit if there's no events to upload
+    // short circuit if there's no events to upload (this shouldn't happen as runFlush makes this check)
     if (!events.length) {
       return;
     }
@@ -1308,6 +1307,7 @@ export class Replay implements Integration {
         replayId,
         segmentId,
         includeReplayStartTimestamp,
+        eventContext,
       });
       this.resetRetries();
       return true;
@@ -1337,6 +1337,7 @@ export class Replay implements Integration {
               events,
               segmentId,
               includeReplayStartTimestamp,
+              eventContext,
             });
             resolve(true);
           } catch (err) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export interface SendReplay {
   replayId: string;
   segmentId: number;
   includeReplayStartTimestamp: boolean;
+  eventContext: PopEventContext;
 }
 
 export type InstrumentationTypeBreadcrumb = 'dom' | 'scope';
@@ -131,18 +132,39 @@ export interface ReplayConfiguration
   extends OptionalReplayPluginOptions,
     RecordingOptions {}
 
-/**
- * Some initial state captured before creating a root replay event
- */
-export interface InitialState {
-  timestamp: number;
-  url: string;
+interface CommonEventContext {
+  /**
+   * The initial URL of the session
+   */
+  initialUrl: string;
+
+  /**
+   * The initial starting timestamp of the session
+   */
+  initialTimestamp: number;
+
+  /**
+   * Ordered list of URLs that have been visited during a replay segment
+   */
+  urls: string[];
+}
+
+export interface PopEventContext extends CommonEventContext {
+  /**
+   * List of Sentry error ids that have occurred during a replay segment
+   */
+  errorIds: Array<string>;
+
+  /**
+   * List of Sentry trace ids that have occurred during a replay segment
+   */
+  traceIds: Array<string>;
 }
 
 /**
  * Additional context that will be sent w/ `replay_event`
  */
-export interface ReplayEventContext {
+export interface InternalEventContext extends CommonEventContext {
   /**
    * Set of Sentry error ids that have occurred during a replay segment
    */
@@ -152,11 +174,6 @@ export interface ReplayEventContext {
    * Set of Sentry trace ids that have occurred during a replay segment
    */
   traceIds: Set<string>;
-
-  /**
-   * Ordered list of URLs that have been visited during a replay segment
-   */
-  urls: string[];
 
   /**
    * The timestamp of the earliest event that has been added to event buffer. This can happen due to the Performance Observer which buffers events.

--- a/test/mocks/mockSdk.ts
+++ b/test/mocks/mockSdk.ts
@@ -40,7 +40,6 @@ class MockTransport implements Transport {
 export async function mockSdk({
   replayOptions = {
     stickySession: true,
-    ignoreClass: 'sentry-test-ignore',
     sessionSampleRate: 1.0,
     errorSampleRate: 0.0,
   },


### PR DESCRIPTION
Moved `popEventContext` up the call tree so that we only pop once instead of right before making the request. Otherwise, when the request fails, the following retries will *not* have the event context as it has been popped and lost.


Additionally:
* Changed tests in `index.test`, we reset the Replay class on every test
* Flattened `context` (removed `initialState`) -- which I could be convinced to revert because the initialState fields should not always get reset.


Fixes #289 