### PR TITLE
replays: increment segment id after finishing buffer

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1103,15 +1103,16 @@ export class Replay implements Integration {
     // Only attach memory event if eventBuffer is not empty
     await this.addMemoryEntry();
 
-    // NOTE: Copy values from instance members, as it's possible they could
-    // change before the flush finishes.
-    const replayId = this.session.id;
-    // Always increment segmentId regardless of outcome of sending replay
-    const segmentId = this.session.segmentId++;
-
     try {
       // Note this empties the event buffer regardless of outcome of sending replay
       const recordingData = await this.eventBuffer.finish();
+
+      // NOTE: Copy values from instance members, as it's possible they could
+      // change before the flush finishes.
+      const replayId = this.session.id;
+      // Always increment segmentId regardless of outcome of sending replay
+      const segmentId = this.session.segmentId++;
+
       await this.sendReplay({
         replayId,
         events: recordingData,


### PR DESCRIPTION
- since in some cases we will not be able to finish sending a replay because we can't run `async` operations in some `visibilitychange` situations, don't increment the segment_id until after we get the data from event buffer. This should help in a bunch of cases where right now we increment and miss the `0`th segment, and additionally help us track down other problems with our flush/transport flow. in order to actually get the data in this situation we'll have to re-architect our event buffer and not do any async operations in our flush flow.