### PR TITLE
chore(deps): Move pako from dependency to devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "jest": "^29.2.1",
     "jest-environment-jsdom": "^29.2.1",
     "jsdom-worker": "^0.2.1",
+    "pako": "^2.0.4",
     "prettier": "^2.5.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.70.0",
@@ -71,7 +72,6 @@
     "@sentry/types": "^7.7.0",
     "@sentry/utils": "^7.7.0",
     "lodash.debounce": "^4.0.8",
-    "pako": "^2.0.4",
     "rrweb": "^1.1.3"
   },
   "prettier": {


### PR DESCRIPTION
As this is (as far as I see) only used at build time to build the worker, we don't actually need to define this as a dependency.

Please let me know if I didn't understand something properly here 😅 

Basically, what I _think_ is happening:

* With `yarn build:worker` the source from `/worker/worker.ts` is built into `/src/worker/worker.js`
* This is then used in the app
* `pako` is only really referenced in `/worker/worker.ts`, in `/src/...` it is actually inlined

(For reference is `build:worker` executed manually whenever something is changed there?)