### PR TITLE
fix: Session storage access throws when disabled

### DIFF
--- a/src/session/fetchSession.test.ts
+++ b/src/session/fetchSession.test.ts
@@ -1,13 +1,19 @@
-import { afterEach, beforeAll, expect, it } from '@jest/globals';
+import { afterEach, beforeAll, expect, it, jest } from '@jest/globals';
 
 import { REPLAY_SESSION_KEY } from './constants';
 import { fetchSession } from './fetchSession';
+
+const oldSessionStorage = window.sessionStorage;
 
 beforeAll(() => {
   window.sessionStorage.clear();
 });
 
 afterEach(() => {
+  Object.defineProperty(window, 'sessionStorage', {
+    writable: true,
+    value: oldSessionStorage,
+  });
   window.sessionStorage.clear();
 });
 
@@ -42,4 +48,17 @@ it('fetches an invalid session', function () {
   );
 
   expect(fetchSession(SAMPLE_RATES)).toBe(null);
+});
+
+it('safely attempts to fetch session when Session Storage is disabled', function () {
+  Object.defineProperty(window, 'sessionStorage', {
+    writable: true,
+    value: {
+      getItem: () => {
+        throw new Error('No Session Storage for you');
+      },
+    },
+  });
+
+  expect(fetchSession(SAMPLE_RATES)).toEqual(null);
 });

--- a/src/session/fetchSession.ts
+++ b/src/session/fetchSession.ts
@@ -16,14 +16,15 @@ export function fetchSession({
     return null;
   }
 
-  const sessionStringFromStorage =
-    window.sessionStorage.getItem(REPLAY_SESSION_KEY);
-
-  if (!sessionStringFromStorage) {
-    return null;
-  }
-
   try {
+    // This can throw if cookies are disabled
+    const sessionStringFromStorage =
+      window.sessionStorage.getItem(REPLAY_SESSION_KEY);
+
+    if (!sessionStringFromStorage) {
+      return null;
+    }
+
     const sessionObj = JSON.parse(sessionStringFromStorage);
 
     return new Session(

--- a/src/session/saveSession.ts
+++ b/src/session/saveSession.ts
@@ -10,6 +10,6 @@ export function saveSession(session: Session) {
   try {
     window.sessionStorage.setItem(REPLAY_SESSION_KEY, JSON.stringify(session));
   } catch {
-    // this shouldn't happen
+    // Ignore potential SecurityError exceptions
   }
 }


### PR DESCRIPTION
sessionStorage access can throw when it (or cookies) are
disabled. Ensure that all API accesses to Session Storage
are doneso safely.

Fixes #316
