### PR TITLE
ref: Move test files to `test/` dir

### DIFF
--- a/jest.config.ts
+++ b/jest.config.ts
@@ -12,6 +12,6 @@ export default async (): Promise<Config.InitialOptions> => {
     }),
     setupFilesAfterEnv: ['./jest.setup.ts'],
     testEnvironment: 'jsdom',
-    testMatch: ['<rootDir>/(src|worker)/**/*(*.)@(spec|test).ts'],
+    testMatch: ['<rootDir>/test/**/*(*.)@(spec|test).ts'],
   };
 };

--- a/test/unit/blockAllMedia.test.ts
+++ b/test/unit/blockAllMedia.test.ts
@@ -1,6 +1,6 @@
 import { mockSdk } from '@test';
 
-import { Replay } from './';
+import { Replay } from '../../src';
 
 let replay: Replay;
 

--- a/test/unit/coreHandlers/handleFetch.test.ts
+++ b/test/unit/coreHandlers/handleFetch.test.ts
@@ -1,6 +1,6 @@
 import { mockSdk } from '@test';
 
-import { handleFetch } from './handleFetch';
+import { handleFetch } from '../../../src/coreHandlers/handleFetch';
 
 jest.unmock('@sentry/browser');
 

--- a/test/unit/coreHandlers/handleScope-unit.test.ts
+++ b/test/unit/coreHandlers/handleScope-unit.test.ts
@@ -1,7 +1,7 @@
 import { getCurrentHub } from '@sentry/core';
 import { mockSdk } from '@test';
 
-import * as HandleScope from './handleScope';
+import * as HandleScope from '../../../src/coreHandlers/handleScope';
 
 let mockHandleScope: jest.MockedFunction<typeof HandleScope.handleScope>;
 

--- a/test/unit/coreHandlers/handleScope.test.ts
+++ b/test/unit/coreHandlers/handleScope.test.ts
@@ -1,6 +1,6 @@
 import type { Breadcrumb, Scope } from '@sentry/types';
 
-import * as HandleScope from './handleScope';
+import * as HandleScope from '../../../src/coreHandlers/handleScope';
 
 jest.spyOn(HandleScope, 'handleScope');
 const mockHandleScope = HandleScope.handleScope as jest.MockedFunction<

--- a/test/unit/createPerformanceEntry.test.ts
+++ b/test/unit/createPerformanceEntry.test.ts
@@ -1,6 +1,6 @@
 import { mockSdk } from '@test';
 
-import { createPerformanceEntries } from './createPerformanceEntry';
+import { createPerformanceEntries } from '../../src/createPerformanceEntry';
 
 jest.unmock('@sentry/browser');
 

--- a/test/unit/eventBuffer.test.ts
+++ b/test/unit/eventBuffer.test.ts
@@ -3,7 +3,10 @@ import 'jsdom-worker';
 import { BASE_TIMESTAMP } from '@test';
 import pako from 'pako';
 
-import { createEventBuffer, EventBufferCompressionWorker } from './eventBuffer';
+import {
+  createEventBuffer,
+  EventBufferCompressionWorker,
+} from './../../src/eventBuffer';
 
 const TEST_EVENT = { data: {}, timestamp: BASE_TIMESTAMP, type: 3 };
 

--- a/test/unit/flush.test.ts
+++ b/test/unit/flush.test.ts
@@ -1,10 +1,10 @@
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { useFakeTimers } from './../test/utils/use-fake-timers';
-import { SESSION_IDLE_DURATION } from './session/constants';
-import { createPerformanceEntries } from './createPerformanceEntry';
-import { Replay } from './';
+import { Replay } from './../../src';
+import { createPerformanceEntries } from './../../src/createPerformanceEntry';
+import { SESSION_IDLE_DURATION } from './../../src/session/constants';
+import { useFakeTimers } from './../../test/utils/use-fake-timers';
 
 useFakeTimers();
 

--- a/test/unit/index-errorSampleRate.test.ts
+++ b/test/unit/index-errorSampleRate.test.ts
@@ -7,12 +7,12 @@ import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resour
 import { resetSdkMock } from '@test/mocks';
 import { DomHandler, MockTransportSend } from '@test/types';
 
-import { useFakeTimers } from './../test/utils/use-fake-timers';
+import { Replay } from './../../src';
 import {
   REPLAY_SESSION_KEY,
   VISIBILITY_CHANGE_TIMEOUT,
-} from './session/constants';
-import { Replay } from './';
+} from './../../src/session/constants';
+import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();
 

--- a/test/unit/index-handleGlobalEvent.test.ts
+++ b/test/unit/index-handleGlobalEvent.test.ts
@@ -2,9 +2,9 @@ import { Error } from '@test/fixtures/error';
 import { Transaction } from '@test/fixtures/transaction';
 import { resetSdkMock } from '@test/mocks';
 
-import { useFakeTimers } from './../test/utils/use-fake-timers';
-import { REPLAY_EVENT_NAME } from './session/constants';
-import { Replay } from './';
+import { Replay } from './../../src';
+import { REPLAY_EVENT_NAME } from './../../src/session/constants';
+import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();
 let replay: Replay;

--- a/test/unit/index-noSticky.test.ts
+++ b/test/unit/index-noSticky.test.ts
@@ -3,12 +3,12 @@ import { Transport } from '@sentry/types';
 import * as SentryUtils from '@sentry/utils';
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { useFakeTimers } from './../test/utils/use-fake-timers';
+import { Replay } from './../../src';
 import {
   SESSION_IDLE_DURATION,
   VISIBILITY_CHANGE_TIMEOUT,
-} from './session/constants';
-import { Replay } from './';
+} from './../../src/session/constants';
+import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();
 

--- a/test/unit/index-sampling.test.ts
+++ b/test/unit/index-sampling.test.ts
@@ -3,7 +3,7 @@ jest.unmock('@sentry/browser');
 // mock functions need to be imported first
 import { mockRrweb, mockSdk } from '@test';
 
-import { useFakeTimers } from './../test/utils/use-fake-timers';
+import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();
 

--- a/test/unit/index.test.ts
+++ b/test/unit/index.test.ts
@@ -1,16 +1,18 @@
-jest.mock('./util/isInternal', () => ({ isInternal: jest.fn(() => true) }));
+jest.mock('./../../src/util/isInternal', () => ({
+  isInternal: jest.fn(() => true),
+}));
 import { BASE_TIMESTAMP, RecordMock } from '@test';
 import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
 import { resetSdkMock } from '@test/mocks';
 import { DomHandler, MockTransportSend } from '@test/types';
 
-import { useFakeTimers } from './../test/utils/use-fake-timers';
+import { Replay } from '../../src';
 import {
   MAX_SESSION_LIFE,
   REPLAY_SESSION_KEY,
   VISIBILITY_CHANGE_TIMEOUT,
-} from './session/constants';
-import { Replay } from './';
+} from '../../src/session/constants';
+import { useFakeTimers } from '../utils/use-fake-timers';
 
 useFakeTimers();
 

--- a/test/unit/multiple-instances.test.ts
+++ b/test/unit/multiple-instances.test.ts
@@ -1,4 +1,4 @@
-import { Replay } from './';
+import { Replay } from './../../src';
 
 it('throws on creating multiple instances', function () {
   expect(() => {

--- a/test/unit/session/Session.test.ts
+++ b/test/unit/session/Session.test.ts
@@ -1,9 +1,9 @@
-jest.mock('./saveSession');
+jest.mock('./../../../src/session/saveSession');
 
 import * as Sentry from '@sentry/browser';
 
-import { saveSession } from './saveSession';
-import { Session } from './Session';
+import { saveSession } from '../../../src/session/saveSession';
+import { Session } from '../../../src/session/Session';
 
 type captureEventMockType = jest.MockedFunction<typeof Sentry.captureEvent>;
 

--- a/test/unit/session/createSession.test.ts
+++ b/test/unit/session/createSession.test.ts
@@ -1,9 +1,9 @@
 import * as Sentry from '@sentry/core';
 
-import { createSession } from './createSession';
-import { saveSession } from './saveSession';
+import { createSession } from '../../../src/session/createSession';
+import { saveSession } from '../../../src/session/saveSession';
 
-jest.mock('./saveSession');
+jest.mock('./../../../src/session/saveSession');
 
 jest.mock('@sentry/utils', () => {
   return {

--- a/test/unit/session/deleteSession.test.ts
+++ b/test/unit/session/deleteSession.test.ts
@@ -1,5 +1,5 @@
-import { REPLAY_SESSION_KEY } from './constants';
-import { deleteSession } from './deleteSession';
+import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
+import { deleteSession } from '../../../src/session/deleteSession';
 
 const storageEngine = window.sessionStorage;
 

--- a/test/unit/session/fetchSession.test.ts
+++ b/test/unit/session/fetchSession.test.ts
@@ -1,5 +1,5 @@
-import { REPLAY_SESSION_KEY } from './constants';
-import { fetchSession } from './fetchSession';
+import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
+import { fetchSession } from '../../../src/session/fetchSession';
 
 const oldSessionStorage = window.sessionStorage;
 

--- a/test/unit/session/getSession.test.ts
+++ b/test/unit/session/getSession.test.ts
@@ -1,8 +1,8 @@
-import * as CreateSession from './createSession';
-import * as FetchSession from './fetchSession';
-import { getSession } from './getSession';
-import { saveSession } from './saveSession';
-import { Session } from './Session';
+import * as CreateSession from '../../../src/session/createSession';
+import * as FetchSession from '../../../src/session/fetchSession';
+import { getSession } from '../../../src/session/getSession';
+import { saveSession } from '../../../src/session/saveSession';
+import { Session } from '../../../src/session/Session';
 
 jest.mock('@sentry/utils', () => {
   return {

--- a/test/unit/session/saveSession.test.ts
+++ b/test/unit/session/saveSession.test.ts
@@ -1,6 +1,6 @@
-import { REPLAY_SESSION_KEY } from './constants';
-import { saveSession } from './saveSession';
-import { Session } from './Session';
+import { REPLAY_SESSION_KEY } from '../../../src/session/constants';
+import { saveSession } from '../../../src/session/saveSession';
+import { Session } from '../../../src/session/Session';
 
 beforeAll(() => {
   window.sessionStorage.clear();

--- a/test/unit/stop.test.ts
+++ b/test/unit/stop.test.ts
@@ -2,9 +2,9 @@ import * as SentryUtils from '@sentry/utils';
 // mock functions need to be imported first
 import { BASE_TIMESTAMP, mockRrweb, mockSdk } from '@test';
 
-import { useFakeTimers } from './../test/utils/use-fake-timers';
-import { SESSION_IDLE_DURATION } from './session/constants';
-import { Replay } from './';
+import { Replay } from './../../src';
+import { SESSION_IDLE_DURATION } from './../../src/session/constants';
+import { useFakeTimers } from './../utils/use-fake-timers';
 
 useFakeTimers();
 

--- a/test/unit/util/dedupePerformanceEntries.test.ts
+++ b/test/unit/util/dedupePerformanceEntries.test.ts
@@ -2,7 +2,7 @@ import { PerformanceEntryLcp } from '@test/fixtures/performanceEntry/lcp';
 import { PerformanceEntryNavigation } from '@test/fixtures/performanceEntry/navigation';
 import { PerformanceEntryResource } from '@test/fixtures/performanceEntry/resource';
 
-import { dedupePerformanceEntries } from './dedupePerformanceEntries';
+import { dedupePerformanceEntries } from '../../../src/util/dedupePerformanceEntries';
 
 it('does nothing with a single entry', function () {
   const entries = [PerformanceEntryNavigation()];

--- a/test/unit/util/isExpired.test.ts
+++ b/test/unit/util/isExpired.test.ts
@@ -1,4 +1,4 @@
-import { isExpired } from './isExpired';
+import { isExpired } from '../../../src/util/isExpired';
 
 it('is expired', function () {
   expect(isExpired(0, 150, 200)).toBe(true); //  expired at ts = 150

--- a/test/unit/util/isSampled.test.ts
+++ b/test/unit/util/isSampled.test.ts
@@ -1,4 +1,4 @@
-import { isSampled } from './isSampled';
+import { isSampled } from '../../../src/util/isSampled';
 
 // Note Math.random generates a value from 0 (inclusive) to <1 (1 exclusive).
 const cases = [

--- a/test/unit/util/isSessionExpired.test.ts
+++ b/test/unit/util/isSessionExpired.test.ts
@@ -1,6 +1,5 @@
-import { Session } from '../session/Session';
-
-import { isSessionExpired } from './isSessionExpired';
+import { Session } from '../../../src/session/Session';
+import { isSessionExpired } from '../../../src/util/isSessionExpired';
 
 function createSession(extra?: Record<string, any>) {
   return new Session(

--- a/test/unit/worker/Compressor.test.ts
+++ b/test/unit/worker/Compressor.test.ts
@@ -1,6 +1,6 @@
 import pako from 'pako';
 
-import { Compressor } from './Compressor';
+import { Compressor } from '../../../worker/src/Compressor';
 
 describe('Compressor', () => {
   it('compresses multiple events', () => {


### PR DESCRIPTION
In order to align with sentry-javascript, move the tests into the `test` folder.

ref https://github.com/getsentry/sentry-replay/issues/311